### PR TITLE
Avoid Int128 operations

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -52,7 +52,9 @@ uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[GPUArrays]]
 deps = ["AbstractFFTs", "Adapt", "LinearAlgebra", "Printf", "Random", "Serialization"]
-git-tree-sha1 = "3b314a595df913db9b3ebf1cb95b4109a2ec185e"
+git-tree-sha1 = "da34298247dead1a3c70d42942eac317adf31dba"
+repo-rev = "5f97bfb"
+repo-url = "https://github.com/JuliaGPU/GPUArrays.jl.git"
 uuid = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
 version = "6.1.0"
 

--- a/lib/level-zero/memory.jl
+++ b/lib/level-zero/memory.jl
@@ -19,9 +19,7 @@ Base.convert(T::Type{<:Union{Ptr,ZePtr}}, buf::AbstractBuffer) =
 Base.unsafe_convert(P::Type{<:Union{Ptr,ZePtr}}, buf::AbstractBuffer) = convert(P, buf)
 
 function free(buf::AbstractBuffer)
-    if pointer(buf) != ZE_NULL
-        zeMemFree(context(buf), buf)
-    end
+    zeMemFree(context(buf), buf)
 end
 
 
@@ -42,8 +40,6 @@ end
 
 function device_alloc(ctx::ZeContext, dev::ZeDevice, bytesize::Integer, alignment::Integer=1;
                       flags=0, ordinal::Integer=0)
-    bytesize == 0 && return DeviceBuffer(ZE_NULL, 0, ctx)
-
     desc_ref = Ref(ze_device_mem_alloc_desc_t(
         ZE_STRUCTURE_TYPE_DEVICE_MEM_ALLOC_DESC, C_NULL,
         flags, ordinal
@@ -85,8 +81,6 @@ struct HostBuffer <: AbstractBuffer
 end
 
 function host_alloc(ctx::ZeContext, bytesize::Integer, alignment::Integer=1; flags=0)
-    bytesize == 0 && return HostBuffer(ZE_NULL, 0, ctx)
-
     desc_ref = Ref(ze_host_mem_alloc_desc_t(
         ZE_STRUCTURE_TYPE_HOST_MEM_ALLOC_DESC, C_NULL,
         flags
@@ -129,8 +123,6 @@ end
 function shared_alloc(ctx::ZeContext, dev::Union{Nothing,ZeDevice}, bytesize::Integer,
                       alignment::Integer=1; host_flags=0,
                       device_flags=0, ordinal::Integer=0)
-    bytesize == 0 && return SharedBuffer(ZE_NULL, 0, ctx)
-
     device_desc_ref = Ref(ze_device_mem_alloc_desc_t(
         ZE_STRUCTURE_TYPE_DEVICE_MEM_ALLOC_DESC, C_NULL,
         device_flags, ordinal

--- a/lib/level-zero/residency.jl
+++ b/lib/level-zero/residency.jl
@@ -4,13 +4,9 @@ export make_resident, evict
 ## memory
 
 function make_resident(ctx::ZeContext, dev::ZeDevice, buf::AbstractBuffer, size=sizeof(buf))
-    if pointer(buf) != ZE_NULL
-        zeContextMakeMemoryResident(ctx, dev, buf, size)
-    end
+    zeContextMakeMemoryResident(ctx, dev, buf, size)
 end
 
 function evict(ctx::ZeContext, dev::ZeDevice, buf::AbstractBuffer, size=sizeof(buf))
-    if pointer(buf) != ZE_NULL
-        zeContextEvictMemory(ctx, dev, buf, size)
-    end
+    zeContextEvictMemory(ctx, dev, buf, size)
 end

--- a/src/oneAPI.jl
+++ b/src/oneAPI.jl
@@ -40,6 +40,7 @@ include("compiler/reflection.jl")
 
 # array abstraction
 include("memory.jl")
+include("pool.jl")
 include("array.jl")
 include("broadcast.jl")
 include("mapreduce.jl")

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -1,0 +1,33 @@
+const allocated = Dict{Tuple{ZeContext,ZePtr},Tuple{oneL0.DeviceBuffer,Int}}()
+
+function allocate(ctx, dev, bytes::Int, alignment::Int)
+    # 0-byte allocations shouldn't hit the pool
+    bytes == 0 && return ZE_NULL
+
+    buf = device_alloc(ctx, dev, bytes, alignment)
+    make_resident(ctx, dev, buf)
+
+    ptr = convert(ZePtr{Nothing}, buf)
+    @assert !haskey(allocated, (ctx,ptr))
+    allocated[(ctx,ptr)] = buf, 1
+
+    return buf
+end
+
+function release(ctx, dev, ptr)
+    # 0-byte allocations shouldn't hit the pool
+    ptr == ZE_NULL && return
+
+    buf, refcount = allocated[(ctx,ptr)]
+    if refcount == 1
+        delete!(allocated, (ctx,ptr))
+    else
+        allocated[(ctx,ptr)] = buf, refcount-1
+        return
+    end
+
+    evict(ctx, dev, buf)
+    free(buf)
+
+    return
+end

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -14,6 +14,16 @@ function allocate(ctx, dev, bytes::Int, alignment::Int)
     return buf
 end
 
+function alias(ctx, dev, ptr)
+    # 0-byte allocations shouldn't hit the pool
+    ptr == ZE_NULL && return
+
+    buf, refcount = allocated[(ctx,ptr)]
+    allocated[(ctx,ptr)] = buf, refcount+1
+
+    return
+end
+
 function release(ctx, dev, ptr)
     # 0-byte allocations shouldn't hit the pool
     ptr == ZE_NULL && return

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,9 +34,9 @@ tests = [
   "input output",
   "interface",
   "iterator constructors",
-# "linear algebra",             # 128-bit mulwide
+  "linear algebra",
   "mapreduce essentials",
-# "mapreduce derivatives",      # 128-bit mulwide
+  "mapreduce derivatives",
   "math",
   "random",
 # "uniformscaling",             # gpu_malloc missing


### PR DESCRIPTION
By bumping GPUArrays, materializing ReshapedArray before sending to the device.