### PR TITLE
Add the result of `get_default_args` as default compiler flags

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,6 +17,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SPIRV_LLVM_Translator_jll = "4a5d46fc-d8cf-5151-a261-86b458210efb"
 SPIRV_Tools_jll = "6ac6d60f-d740-5983-97d7-a4482c0689f4"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
+oneAPI_Level_Zero_Headers_jll = "f4bc562b-d309-54f8-9efb-476e56f0410d"
 oneAPI_Level_Zero_Loader_jll = "13eca655-d68d-5b81-8367-6d99d727ab01"
 
 [compat]

--- a/lib/level-zero/libze.jl
+++ b/lib/level-zero/libze.jl
@@ -3633,10 +3633,6 @@ end
 
 const ze_callbacks_t = _ze_callbacks_t
 
-const ZE_APICALL = nothing
-
-const ZE_APIEXPORT = nothing
-
 # Skipping MacroDefinition: ZE_DLLEXPORT __attribute__ ( ( visibility ( "default" ) ) )
 
 const ZE_MAX_IPC_HANDLE_SIZE = 64

--- a/res/Manifest.toml
+++ b/res/Manifest.toml
@@ -16,17 +16,17 @@ version = "0.4.1"
 
 [[CSTParser]]
 deps = ["Tokenize"]
-git-tree-sha1 = "d099404ed1319a69fca328814e9a7ad46b32ab67"
+git-tree-sha1 = "ffc3860cb53809f4fef6bc94117efab53975ad15"
 uuid = "00ebfdb7-1f24-5e51-bd34-a7502290713f"
-version = "3.1.0"
+version = "3.2.0"
 
 [[Clang]]
-deps = ["CEnum", "Clang_jll", "TOML"]
-git-tree-sha1 = "da3729e8289a2202fc87c34f232fabc92e338b11"
-repo-rev = "dag"
+deps = ["CEnum", "Clang_jll", "Downloads", "Pkg", "TOML"]
+git-tree-sha1 = "468f7fead4786ebe67b8d12b9516971cdd31e651"
+repo-rev = "master"
 repo-url = "https://github.com/JuliaInterop/Clang.jl.git"
 uuid = "40e3b903-d033-50b4-a0cc-940c62c95e31"
-version = "0.13.0"
+version = "0.14.0"
 
 [[Clang_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "libLLVM_jll"]
@@ -47,9 +47,10 @@ deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[JLLWrappers]]
-git-tree-sha1 = "a431f5f2ca3f4feef3bd7a5e94b8b8d4f2f647a0"
+deps = ["Preferences"]
+git-tree-sha1 = "642a199af8b68253517b80bd3bfd17eb4e84df6e"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
-version = "1.2.0"
+version = "1.3.0"
 
 [[LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
@@ -90,6 +91,12 @@ uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 [[Pkg]]
 deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "ea79e4c9077208cd3bc5d29631a26bc0cff78902"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.2.1"
 
 [[Printf]]
 deps = ["Unicode"]

--- a/res/Project.toml
+++ b/res/Project.toml
@@ -3,3 +3,6 @@ CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"
 Clang = "40e3b903-d033-50b4-a0cc-940c62c95e31"
 Tokenize = "0796e94c-ce3b-5d07-9a54-7f471281c624"
 oneAPI_Level_Zero_Headers_jll = "f4bc562b-d309-54f8-9efb-476e56f0410d"
+
+[compat]
+Clang = "0.14.0"

--- a/res/wrap.jl
+++ b/res/wrap.jl
@@ -12,7 +12,8 @@ function wrap(name, headers...; library="lib$name", defines=[], include_dirs=[])
     options["general"]["library_name"] = library
     options["general"]["output_file_path"] = "lib$(name).jl"
 
-    ctx = create_context([headers...], String[], options)
+    args = get_default_args()
+    ctx = create_context([headers...], args, options)
 
     build!(ctx)
 


### PR DESCRIPTION
Switch Clang.jl's version in Manifest.toml to master and use `get_default_args` to setup default compiler flags which is more stable.  