### PR TITLE
Disable level zero optimizations per default

### DIFF
--- a/lib/level-zero/module.jl
+++ b/lib/level-zero/module.jl
@@ -8,7 +8,7 @@ mutable struct ZeModule
     context::ZeContext
     device::ZeDevice
 
-    function ZeModule(ctx::ZeContext, dev::ZeDevice, image; build_flags="", log::Bool=true)
+    function ZeModule(ctx::ZeContext, dev::ZeDevice, image; build_flags="-ze-opt-disable", log::Bool=true)
         log_ref = if log
             log_ref = Ref{ze_module_build_log_handle_t}()
         else


### PR DESCRIPTION
When running on

Intel Corporation TigerLake-LP GT2 [Iris Xe Graphics] (rev 01)

The test suite stalls when llvm-optimization in level zero are enabled.

Disabling level zero optimizations solves the problem.