### PR TITLE
Use a blocking free to avoid early memory releases.

### DIFF
--- a/lib/level-zero/memory.jl
+++ b/lib/level-zero/memory.jl
@@ -18,8 +18,14 @@ Base.convert(T::Type{<:Union{Ptr,ZePtr}}, buf::AbstractBuffer) =
 # and not the pointer of the buffer object itself.
 Base.unsafe_convert(P::Type{<:Union{Ptr,ZePtr}}, buf::AbstractBuffer) = convert(P, buf)
 
-function free(buf::AbstractBuffer)
-    zeMemFree(context(buf), buf)
+function free(buf::AbstractBuffer; policy=nothing)
+    ctx = context(buf)
+    if policy === nothing
+        zeMemFree(ctx, buf)
+    else
+        desc_ref = Ref(ze_memory_free_ext_desc_t(; freePolicy=policy))
+        zeMemFreeExt(ctx, desc_ref, buf)
+    end
 end
 
 

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -14,7 +14,10 @@ function release(buf::oneL0.AbstractBuffer)
     dev = oneL0.device(buf)
 
     evict(ctx, dev, buf)
-    free(buf)
+    free(buf; policy=oneL0.ZE_DRIVER_MEMORY_FREE_POLICY_EXT_FLAG_BLOCKING_FREE)
+
+    # TODO: queue-ordered free from non-finalizer tasks once we have
+    #       `zeMemFreeAsync(ptr, queue)`
 
     return
 end


### PR DESCRIPTION
Should fix https://github.com/JuliaGPU/oneAPI.jl/issues/113