### PR TITLE
Ensure the barrier function is convergent.

### DIFF
--- a/src/device/opencl/synchronization.jl
+++ b/src/device/opencl/synchronization.jl
@@ -6,4 +6,16 @@ const cl_mem_fence_flags = Cuint
 const CLK_LOCAL_MEM_FENCE = cl_mem_fence_flags(1)
 const CLK_GLOBAL_MEM_FENCE = cl_mem_fence_flags(2)
 
-barrier(flags=0) = @builtin_ccall("barrier", Cvoid, (Cuint,), flags)
+#barrier(flags=0) = @builtin_ccall("barrier", Cvoid, (Cuint,), flags)
+barrier(flags=0) = Base.llvmcall(("""
+        declare void @_Z7barrierj(i32) #0
+        define void @entry(i32 %0) #1 {
+            call void @_Z7barrierj(i32 %0)
+            ret void
+        }
+        attributes #0 = { convergent }
+        attributes #1 = { alwaysinline }
+        """, "entry"),
+    Cvoid, Tuple{Int32}, convert(Int32, flags))
+push!(opencl_builtins, "_Z7barrierj")
+# TODO: add support for attributes to @builting_ccall/LLVM.@typed_ccall


### PR DESCRIPTION
Otherwise LLVM can reorder it in a way that the resulting control flow is invalid for a barrier.
Fixes https://github.com/JuliaGPU/oneAPI.jl/issues/160, fixes https://github.com/JuliaGPU/oneAPI.jl/issues/159