### PR TITLE
Update tb/onemkl to the latest SYCL API

### DIFF
--- a/deps/onemkl.cpp
+++ b/deps/onemkl.cpp
@@ -20,8 +20,8 @@ oneapi::mkl::transpose convert(onemklTranspose val) {
 
 extern "C" int onemklHgemm(syclQueue_t device_queue, onemklTranspose transA,
                            onemklTranspose transB, int64_t m, int64_t n,
-                           int64_t k, half alpha, const half *A, int64_t lda,
-                           const half *B, int64_t ldb, half beta, half *C,
+                           int64_t k, sycl::half alpha, const sycl::half *A, int64_t lda,
+                           const sycl::half *B, int64_t ldb, sycl::half beta, sycl::half *C,
                            int64_t ldc) {
     oneapi::mkl::blas::column_major::gemm(device_queue->val, convert(transA),
                                           convert(transB), m, n, k, alpha, A,

--- a/deps/sycl.cpp
+++ b/deps/sycl.cpp
@@ -1,12 +1,12 @@
 #include "sycl.hpp"
 
-#include <CL/sycl/backend/level_zero.hpp>
+#include <sycl/ext/oneapi/backend/level_zero.hpp>
 
-// https://github.com/intel/llvm/blob/sycl/sycl/include/CL/sycl/backend/level_zero.hpp
+// https://github.com/intel/llvm/blob/sycl/sycl/include/sycl/ext/oneapi/backend/level_zero.hpp
 
 extern "C" int syclPlatformCreate(syclPlatform_t *obj,
                                   ze_driver_handle_t driver) {
-    auto sycl_platform = sycl::level_zero::make<sycl::platform>(driver);
+    auto sycl_platform = sycl::ext::oneapi::level_zero::make_platform((pi_native_handle) driver);
     *obj = new syclPlatform_st({sycl_platform});
     return 0;
 }
@@ -19,7 +19,7 @@ extern "C" int syclPlatformDestroy(syclPlatform_t obj) {
 extern "C" int syclDeviceCreate(syclDevice_t *obj, syclPlatform_t platform,
                                 ze_device_handle_t device) {
     auto sycl_device =
-        sycl::level_zero::make<sycl::device>(platform->val, device);
+        sycl::ext::oneapi::level_zero::make_device(platform->val, (pi_native_handle) device);
     *obj = new syclDevice_st({sycl_device});
     return 0;
 }
@@ -35,10 +35,9 @@ extern "C" int syclContextCreate(syclContext_t *obj, syclDevice_t *devices,
     std::vector<sycl::device> sycl_devices(ndevices);
     for (size_t i = 0; i < ndevices; i++)
         sycl_devices[i] = devices[i]->val;
-    auto ownership = keep_ownership ? sycl::level_zero::ownership::keep
-                                    : sycl::level_zero::ownership::transfer;
+    
     auto sycl_context =
-        sycl::level_zero::make<sycl::context>(sycl_devices, context, ownership);
+        sycl::ext::oneapi::level_zero::make_context(sycl_devices, (pi_native_handle) context, keep_ownership);
     *obj = new syclContext_st({sycl_context});
     return 0;
 }
@@ -51,10 +50,8 @@ extern "C" int syclContextDestroy(syclContext_t obj) {
 extern "C" int syclQueueCreate(syclQueue_t *obj, syclContext_t context,
                                ze_command_queue_handle_t queue,
                                int keep_ownership) {
-    auto ownership = keep_ownership ? sycl::level_zero::ownership::keep
-                                    : sycl::level_zero::ownership::transfer;
     // XXX: ownership argument only used on master
-    auto sycl_queue = sycl::level_zero::make<sycl::queue>(context->val, queue);
+    auto sycl_queue = sycl::ext::oneapi::level_zero::make_queue(context->val, (pi_native_handle) queue, keep_ownership);
     *obj = new syclQueue_st({sycl_queue});
     return 0;
 }

--- a/src/compiler/execution.jl
+++ b/src/compiler/execution.jl
@@ -166,7 +166,7 @@ end
 @inline function onecall(kernel::ZeKernel, tt, args...; groups::ZeDim=1, items::ZeDim=1,
                          queue::ZeCommandQueue=global_queue(context(), device()))
     for (i, arg) in enumerate(args)
-        arguments(kernel)[i] = arg
+        oneL0.arguments(kernel)[i] = arg
     end
 
     groupsize!(kernel, items)


### PR DESCRIPTION
I made a few small changes to bring the tb/onemkl branch to the latest SYCL API changes.  It builds successfully but the call to MKL gemm still aborts at runtime. It will be good to get the changes in so we can debug the MKL problem with the latest SYCL compiler and MKL.  Please review. 