### PR TITLE
Re-enable tests for Int16/Float16.

### DIFF
--- a/test/setup.jl
+++ b/test/setup.jl
@@ -8,10 +8,9 @@ gpuarrays_root = dirname(dirname(gpuarrays))
 include(joinpath(gpuarrays_root, "test", "testsuite.jl"))
 testf(f, xs...; kwargs...) = TestSuite.compare(f, oneArray, xs...; kwargs...)
 
-# JuliaGPU/oneAPI.jl#108: fill! broken for Int16/Float16
-const eltypes = [Int32, Int64,
+const eltypes = [Int16, Int32, Int64,
                  Complex{Int16}, Complex{Int32}, Complex{Int64},
-                 Float32,
+                 Float16, Float32,
                  ComplexF32]
 const float16_supported = oneL0.module_properties(device()).fp64flags & oneL0.ZE_DEVICE_MODULE_FLAG_FP16 == oneL0.ZE_DEVICE_MODULE_FLAG_FP16
 if float16_supported


### PR DESCRIPTION
Closes https://github.com/JuliaGPU/oneAPI.jl/issues/108.