### PR TITLE
Call oneapi::mkl::gpu::clean_device_info_cache before destroy sycl::q…

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,6 +13,8 @@ steps:
             - src
             - lib
             - examples
+    artifact_paths:
+      - "deps/build.log"
     agents:
       queue: "juliagpu"
       intel: "*"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -22,6 +22,8 @@ end
 Conda.add("dpcpp_linux-64", conda_dir; channel="intel")
 Conda.add("mkl-devel-dpcpp", conda_dir; channel="intel")
 
+Conda.list(conda_dir)
+
 # XXX: isn't there a Conda package providing ze_api.hpp?
 include_dir =  joinpath(oneAPI_Level_Zero_Headers_jll.artifact_dir, "include")
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -24,6 +24,8 @@ Conda.add("mkl-devel-dpcpp", conda_dir; channel="intel")
 
 Conda.list(conda_dir)
 
+run(pipeline(`nm -D $(Conda.lib_dir(conda_dir))/libmkl_sycl.so`, `grep clean_device_info`))
+
 # XXX: isn't there a Conda package providing ze_api.hpp?
 include_dir =  joinpath(oneAPI_Level_Zero_Headers_jll.artifact_dir, "include")
 

--- a/deps/onemkl.cpp
+++ b/deps/onemkl.cpp
@@ -3,17 +3,6 @@
 
 #include <oneapi/mkl.hpp>
 
-#ifdef __cplusplus
-// work around to expose mkl gpu cleanup
-namespace oneapi {
-namespace mkl {
-namespace gpu {
-int clean_device_info_cache();
-}
-}
-}
-#endif
-
 // gemm
 
 // https://spec.oneapi.io/versions/1.0-rev-1/elements/oneMKL/source/domains/blas/gemm.html
@@ -90,6 +79,21 @@ extern "C" int onemklZgemm(syclQueue_t device_queue, onemklTranspose transA,
         reinterpret_cast<const std::complex<double> *>(B), ldb, beta,
         reinterpret_cast<std::complex<double> *>(C), ldc);
     return 0;
+}
+
+
+// other
+
+// oneMKL keeps a cache of SYCL queues and tries to destroy them when unloading the library.
+// that is incompatible with oneAPI.jl destroying queues before that, so expose a function
+// to manually wipe the device cache when we're destroying queues.
+
+namespace oneapi {
+namespace mkl {
+namespace gpu {
+int clean_device_info_cache();
+}
+}
 }
 
 extern "C" void onemklDestroy() {

--- a/deps/onemkl.cpp
+++ b/deps/onemkl.cpp
@@ -91,11 +91,11 @@ extern "C" int onemklZgemm(syclQueue_t device_queue, onemklTranspose transA,
 namespace oneapi {
 namespace mkl {
 namespace gpu {
-int clean_device_info_cache();
+int clean_gpu_caches();
 }
 }
 }
 
 extern "C" void onemklDestroy() {
-    oneapi::mkl::gpu::clean_device_info_cache();
+    oneapi::mkl::gpu::clean_gpu_caches();
 }

--- a/deps/onemkl.cpp
+++ b/deps/onemkl.cpp
@@ -3,6 +3,17 @@
 
 #include <oneapi/mkl.hpp>
 
+#ifdef __cplusplus
+// work around to expose mkl gpu cleanup
+namespace oneapi {
+namespace mkl {
+namespace gpu {
+int clean_device_info_cache();
+}
+}
+}
+#endif
+
 // gemm
 
 // https://spec.oneapi.io/versions/1.0-rev-1/elements/oneMKL/source/domains/blas/gemm.html
@@ -79,4 +90,8 @@ extern "C" int onemklZgemm(syclQueue_t device_queue, onemklTranspose transA,
         reinterpret_cast<const std::complex<double> *>(B), ldb, beta,
         reinterpret_cast<std::complex<double> *>(C), ldc);
     return 0;
+}
+
+extern "C" void onemklDestroy() {
+    oneapi::mkl::gpu::clean_device_info_cache();
 }

--- a/deps/onemkl.h
+++ b/deps/onemkl.h
@@ -39,6 +39,7 @@ int onemklZgemm(syclQueue_t device_queue, onemklTranspose transA,
                 const double _Complex *B, int64_t ldb, double _Complex beta,
                 double _Complex *C, int64_t ldc);
 
+void onemklDestroy();
 #ifdef __cplusplus
 }
 #endif

--- a/examples/gemm.jl
+++ b/examples/gemm.jl
@@ -7,5 +7,3 @@ B = oneArray(rand(Float32, 3, 4))
 C = A * B
 
 @test Array(C) ≈ Array(A) * Array(B)
-
-println("Done")

--- a/lib/sycl/SYCL.jl
+++ b/lib/sycl/SYCL.jl
@@ -55,6 +55,7 @@ mutable struct syclContext
     syclContextCreate(handle, devs, length(devs), ze_ctx, true)
     obj = new(handle[], devs, ze_ctx)
     finalizer(obj) do ctx
+      onemklDestroy()
       syclContextDestroy(ctx)
     end
   end
@@ -73,7 +74,6 @@ mutable struct syclQueue
     syclQueueCreate(handle, ctx, ze_queue, true)
     obj = new(handle[], ctx, ze_queue)
     finalizer(obj) do queue
-      onemklDestroy()
       syclQueueDestroy(queue)
     end
   end

--- a/lib/sycl/SYCL.jl
+++ b/lib/sycl/SYCL.jl
@@ -73,6 +73,7 @@ mutable struct syclQueue
     syclQueueCreate(handle, ctx, ze_queue, true)
     obj = new(handle[], ctx, ze_queue)
     finalizer(obj) do queue
+      onemklDestroy()
       syclQueueDestroy(queue)
     end
   end

--- a/lib/sycl/libsycl.jl
+++ b/lib/sycl/libsycl.jl
@@ -68,3 +68,7 @@ end
 function syclEventDestroy(obj)
     @ccall liboneapilib.syclEventDestroy(obj::syclEvent_t)::Cint
 end
+
+function onemklDestroy()
+    @ccall liboneapilib.onemklDestroy()::Cvoid
+end


### PR DESCRIPTION
…ueue, a temporary fix until a public oneMKL function is available

This fixes the tear down segfault on my system.  The oneMKL team will add a new public clean up function in a future update.