### PR TITLE
Support level-2 primitives and dot (level-1) primitive

### DIFF
--- a/deps/src/onemkl.cpp
+++ b/deps/src/onemkl.cpp
@@ -24,6 +24,24 @@ oneapi::mkl::transpose convert(onemklTranspose val) {
     }
 }
 
+oneapi::mkl::uplo convert(onemklUplo val) {
+    switch(val) {
+        case ONEMKL_UPLO_UPPER:
+            return oneapi::mkl::uplo::upper;
+        case ONEMKL_UPLO_LOWER:
+            return oneapi::mkl::uplo::lower;
+    }
+}
+
+oneapi::mkl::diag convert(onemklDiag val) {
+    switch(val) {
+        case ONEMKL_DIAG_NONUNIT:
+            return oneapi::mkl::diag::nonunit;
+        case ONEMKL_DIAG_UNIT:
+            return oneapi::mkl::diag::unit;
+    }
+}
+
 extern "C" int onemklHgemm(syclQueue_t device_queue, onemklTranspose transA,
                            onemklTranspose transB, int64_t m, int64_t n,
                            int64_t k, sycl::half alpha, const sycl::half *A, int64_t lda,
@@ -87,6 +105,54 @@ extern "C" int onemklZgemm(syclQueue_t device_queue, onemklTranspose transA,
     return 0;
 }
 
+extern "C" void onemklSgbmv(syclQueue_t device_queue, onemklTranspose trans,
+                            int64_t m, int64_t n, int64_t kl, int64_t ku, 
+                            float alpha, const float *a, int64_t lda,
+                            const float *x, int64_t incx, float beta, float *y,
+                            int64_t incy) {
+    auto status = oneapi::mkl::blas::column_major::gbmv(device_queue->val,
+                                convert(trans), m, n, kl, ku, alpha, a, lda, x,
+                                incx, beta, y, incy);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklDgbmv(syclQueue_t device_queue, onemklTranspose trans,
+                            int64_t m, int64_t n, int64_t kl, int64_t ku, 
+                            double alpha, const double *a, int64_t lda,
+                            const double *x, int64_t incx, double beta, double *y,
+                            int64_t incy) {
+    auto status = oneapi::mkl::blas::column_major::gbmv(device_queue->val, convert(trans),
+                                    m, n, kl, ku, alpha, a, lda, x, incx, beta, y, incy);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklCgbmv(syclQueue_t device_queue, onemklTranspose trans,
+                            int64_t m, int64_t n, int64_t kl, int64_t ku, 
+                            float _Complex alpha, const float _Complex *a, int64_t lda,
+                            const float _Complex *x, int64_t incx, float _Complex beta,
+                            float _Complex *y, int64_t incy) {
+    auto status = oneapi::mkl::blas::column_major::gbmv(device_queue->val, convert(trans),
+                                    m, n, kl, ku, static_cast<std::complex<float> >(alpha),
+                                    reinterpret_cast<const std::complex<float> *>(a),
+                                    lda, reinterpret_cast<const std::complex<float> *>(x),
+                                    incx, static_cast<std::complex<float> >(beta), 
+                                    reinterpret_cast<std::complex<float> *>(y), incy);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklZgbmv(syclQueue_t device_queue, onemklTranspose trans,
+                            int64_t m, int64_t n, int64_t kl, int64_t ku, 
+                            double _Complex alpha, const double _Complex *a, int64_t lda,
+                            const double _Complex *x, int64_t incx, double _Complex beta,
+                            double _Complex *y, int64_t incy) {
+    auto status = oneapi::mkl::blas::column_major::gbmv(device_queue->val, convert(trans), m,
+                                        n, kl, ku, static_cast<std::complex<double> >(alpha),
+                                        reinterpret_cast<const std::complex<double> *>(a),
+                                        lda, reinterpret_cast<const std::complex<double> *>(x), incx,
+                                        static_cast<std::complex<double> >(beta),
+                                        reinterpret_cast<std::complex<double> *>(y), incy);
+    __FORCE_MKL_FLUSH__(status);
+}
 
 extern "C" void onemklSdot(syclQueue_t device_queue, int64_t n,
                            const float *x, int64_t incx, const float *y,
@@ -207,6 +273,7 @@ extern "C" void onemklZaxpy(syclQueue_t device_queue, int64_t n, double _Complex
                             reinterpret_cast<std::complex<double> *>(y), incy);
     __FORCE_MKL_FLUSH__(status);
 }
+
 // Support Level-1: SCAL primitive
 extern "C" void onemklDscal(syclQueue_t device_queue, int64_t n, double alpha,
                             double *x, int64_t incx) {
@@ -257,6 +324,336 @@ extern "C" void onemklZdscal(syclQueue_t device_queue, int64_t n,
     __FORCE_MKL_FLUSH__(status);
 }
 
+
+extern "C" void onemklSgemv(syclQueue_t device_queue, onemklTranspose trans,
+                            int64_t m, int64_t n, float alpha, const float *a,
+                            int64_t lda, const float *x, int64_t incx, float beta,
+                            float *y, int64_t incy) {
+    auto status = oneapi::mkl::blas::column_major::gemv(device_queue->val, convert(trans),
+                                            m, n, alpha, a, lda, x, incx, beta, y, incy);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklDgemv(syclQueue_t device_queue, onemklTranspose trans,
+                            int64_t m, int64_t n, double alpha, const double *a,
+                            int64_t lda, const double *x, int64_t incx, double beta,
+                            double *y, int64_t incy) {
+    auto status = oneapi::mkl::blas::column_major::gemv(device_queue->val, convert(trans),
+                                            m, n, alpha, a, lda, x, incx, beta, y, incy);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklCgemv(syclQueue_t device_queue, onemklTranspose trans,
+                            int64_t m, int64_t n, float _Complex alpha,
+                            const float _Complex *a, int64_t lda,
+                            const float _Complex *x, int64_t incx,
+                            float _Complex beta, float _Complex *y,
+                            int64_t incy) {
+    auto status = oneapi::mkl::blas::column_major::gemv(device_queue->val, convert(trans), m, n,
+                                            static_cast<std::complex<float> >(alpha),
+                                            reinterpret_cast<const std::complex<float> *>(a), lda,
+                                            reinterpret_cast<const std::complex<float> *>(x), incx,
+                                            static_cast<std::complex<float> >(beta),
+                                            reinterpret_cast<std::complex<float> *>(y), incy);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklZgemv(syclQueue_t device_queue, onemklTranspose trans,
+                            int64_t m, int64_t n, double _Complex alpha,
+                            const double _Complex *a, int64_t lda,
+                            const double _Complex *x, int64_t incx,
+                            double _Complex beta, double _Complex *y,
+                            int64_t incy) {
+    auto status = oneapi::mkl::blas::column_major::gemv(device_queue->val, convert(trans), m, n,
+                                            static_cast<std::complex<double> >(alpha),
+                                            reinterpret_cast<const std::complex<double> *>(a), lda,
+                                            reinterpret_cast<const std::complex<double> *>(x), incx,
+                                            static_cast<std::complex<double> >(beta),
+                                            reinterpret_cast<std::complex<double> *>(y), incy);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklSger(syclQueue_t device_queue, int64_t m, int64_t n, float alpha,
+                           const float *x, int64_t incx, const float *y, int64_t incy,
+                           float *a, int64_t lda) {
+    auto status = oneapi::mkl::blas::column_major::ger(device_queue->val, m, n, alpha, x,
+                                                    incx, y, incy, a, lda);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklDger(syclQueue_t device_queue, int64_t m, int64_t n, double alpha,
+                           const double *x, int64_t incx, const double *y, int64_t incy,
+                           double *a, int64_t lda) {
+    auto status = oneapi::mkl::blas::column_major::ger(device_queue->val, m, n, alpha, x,
+                                                    incx, y, incy, a, lda);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklCgerc(syclQueue_t device_queue, int64_t m, int64_t n, float _Complex alpha,
+                           const float _Complex *x, int64_t incx, const float _Complex *y, int64_t incy,
+                           float _Complex *a, int64_t lda) {
+    auto status = oneapi::mkl::blas::column_major::gerc(device_queue->val, m, n,
+                                            static_cast<std::complex<float> >(alpha),
+                                            reinterpret_cast<const std::complex<float> *>(x), incx,
+                                            reinterpret_cast<const std::complex<float> *>(y), incy,
+                                            reinterpret_cast<std::complex<float> *>(a), lda);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklZgerc(syclQueue_t device_queue, int64_t m, int64_t n, double _Complex alpha,
+                           const double _Complex *x, int64_t incx, const double _Complex *y, int64_t incy,
+                           double _Complex *a, int64_t lda) {
+    auto status = oneapi::mkl::blas::column_major::gerc(device_queue->val, m, n,
+                                          static_cast<std::complex<float> >(alpha),
+                                          reinterpret_cast<const std::complex<double> *>(x), incx,
+                                          reinterpret_cast<const std::complex<double> *>(y), incy,
+                                          reinterpret_cast<std::complex<double> *>(a), lda);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklChemv(syclQueue_t device_queue, onemklUplo uplo, int64_t n,
+                            float _Complex alpha, const float _Complex *a, int64_t lda,
+                            const float _Complex *x, int64_t incx, float _Complex beta,
+                            float _Complex *y, int64_t incy) {
+    auto status = oneapi::mkl::blas::column_major::hemv(device_queue->val, convert(uplo), n,
+                                          static_cast<std::complex<float> >(alpha), 
+                                          reinterpret_cast<const std::complex<float> *>(a),
+                                          lda, reinterpret_cast<const std::complex<float> *>(x), incx,
+                                          static_cast<std::complex<float> >(beta), 
+                                          reinterpret_cast<std::complex<float> *>(y), incy);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklZhemv(syclQueue_t device_queue, onemklUplo uplo, int64_t n,
+                            double _Complex alpha, const double _Complex *a, int64_t lda,
+                            const double _Complex *x, int64_t incx, double _Complex beta,
+                            double _Complex *y, int64_t incy) {
+    auto status = oneapi::mkl::blas::column_major::hemv(device_queue->val, convert(uplo), n,
+                                          static_cast<std::complex<double> >(alpha), 
+                                          reinterpret_cast<const std::complex<double> *>(a),
+                                          lda, reinterpret_cast<const std::complex<double> *>(x), incx,
+                                          static_cast<std::complex<double> >(beta),
+                                          reinterpret_cast<std::complex<double> *>(y), incy);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklChbmv(syclQueue_t device_queue, onemklUplo uplo, int64_t n,
+                            int64_t k, float _Complex alpha, const float _Complex *a,
+                            int64_t lda, const float _Complex *x, int64_t incx, float _Complex beta,
+                            float _Complex *y, int64_t incy) {
+    auto status = oneapi::mkl::blas::column_major::hbmv(device_queue->val, convert(uplo), n,
+                                          k, static_cast<std::complex<float> >(alpha),
+                                          reinterpret_cast<const std::complex<float> *>(a),
+                                          lda, reinterpret_cast<const std::complex<float> *>(x),
+                                          incx, static_cast<std::complex<float> >(beta),
+                                          reinterpret_cast<std::complex<float> *>(y), incy);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklZhbmv(syclQueue_t device_queue, onemklUplo uplo, int64_t n,
+                            int64_t k, double _Complex alpha, const double _Complex *a,
+                            int64_t lda, const double _Complex *x, int64_t incx, double _Complex beta,
+                            double _Complex *y, int64_t incy) {
+    auto status = oneapi::mkl::blas::column_major::hbmv(device_queue->val, convert(uplo), n,
+                                          k, static_cast<std::complex<double> >(alpha),
+                                          reinterpret_cast<const std::complex<double> *>(a),
+                                          lda, reinterpret_cast<const std::complex<double> *>(x),
+                                          incx, static_cast<std::complex<double> >(beta),
+                                          reinterpret_cast<std::complex<double> *>(y), incy);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklCher(syclQueue_t device_queue, onemklUplo uplo, int64_t n, float alpha,
+                           const float _Complex *x, int64_t incx, float _Complex *a,
+                           int64_t lda) {
+    auto status = oneapi::mkl::blas::column_major::her(device_queue->val, convert(uplo), n, alpha,
+                                        reinterpret_cast<const std::complex<float> *>(x), incx,
+                                        reinterpret_cast<std::complex<float> *>(a), lda);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklZher(syclQueue_t device_queue, onemklUplo uplo, int64_t n, double alpha,
+                           const double _Complex *x, int64_t incx, double _Complex *a,
+                           int64_t lda) {
+    auto status = oneapi::mkl::blas::column_major::her(device_queue->val, convert(uplo), n, alpha,
+                                        reinterpret_cast<const std::complex<double> *>(x), incx,
+                                        reinterpret_cast<std::complex<double> *>(a), lda);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklCher2(syclQueue_t device_queue, onemklUplo uplo, int64_t n, float _Complex alpha,
+                            const float _Complex *x, int64_t incx, const float _Complex *y, int64_t incy,
+                            float _Complex *a, int64_t lda) {
+    auto status = oneapi::mkl::blas::column_major::her2(device_queue->val, convert(uplo), n,
+                                          static_cast<std::complex<float> >(alpha),
+                                          reinterpret_cast<const std::complex<float> *>(x), incx,
+                                          reinterpret_cast<const std::complex<float> *>(y), incy,
+                                          reinterpret_cast<std::complex<float> *>(a), lda);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklZher2(syclQueue_t device_queue, onemklUplo uplo, int64_t n, double _Complex alpha,
+                            const double _Complex *x, int64_t incx, const double _Complex *y, int64_t incy,
+                            double _Complex *a, int64_t lda) {
+    auto status = oneapi::mkl::blas::column_major::her2(device_queue->val, convert(uplo), n,
+                                          static_cast<std::complex<double> >(alpha),
+                                          reinterpret_cast<const std::complex<double> *>(x), incx,
+                                          reinterpret_cast<const std::complex<double> *>(y), incy,
+                                          reinterpret_cast<std::complex<double> *>(a), lda);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklSsbmv(syclQueue_t device_queue, onemklUplo uplo, int64_t n, int64_t k,
+                            float alpha, const float *a, int64_t lda, const float *x, 
+                            int64_t incx, float beta, float *y, int64_t incy) {
+    auto status = oneapi::mkl::blas::column_major::sbmv(device_queue->val, convert(uplo), n, k,
+                                                    alpha, a, lda, x, incx, beta, y, incy);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklDsbmv(syclQueue_t device_queue, onemklUplo uplo, int64_t n, int64_t k,
+                            double alpha, const double *a, int64_t lda, const double *x, 
+                            int64_t incx, double beta, double *y, int64_t incy) {
+    auto status = oneapi::mkl::blas::column_major::sbmv(device_queue->val, convert(uplo), n, k,
+                                                    alpha, a, lda, x, incx, beta, y, incy);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklSsymv(syclQueue_t device_queue, onemklUplo uplo, int64_t n, float alpha,
+                            const float *a, int64_t lda, const float *x, int64_t incx, float beta,
+                            float *y, int64_t incy) {
+    auto status = oneapi::mkl::blas::column_major::symv(device_queue->val, convert(uplo), n, alpha,
+                                                    a, lda, x, incx, beta, y, incy);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklDsymv(syclQueue_t device_queue, onemklUplo uplo, int64_t n, double alpha,
+                            const double *a, int64_t lda, const double *x, int64_t incx, double beta,
+                            double *y, int64_t incy) {
+    auto status = oneapi::mkl::blas::column_major::symv(device_queue->val, convert(uplo), n, alpha,
+                                                    a, lda, x, incx, beta, y, incy);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklSsyr(syclQueue_t device_queue, onemklUplo uplo, int64_t n, float alpha,
+                           const float *x, int64_t incx, float *a, int64_t lda) {
+    auto status = oneapi::mkl::blas::column_major::syr(device_queue->val, convert(uplo), n, alpha,
+                                                    x, incx, a, lda);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklDsyr(syclQueue_t device_queue, onemklUplo uplo, int64_t n, double alpha,
+                           const double *x, int64_t incx, double *a, int64_t lda) {
+    auto status = oneapi::mkl::blas::column_major::syr(device_queue->val, convert(uplo), n, alpha,
+                                                    x, incx, a, lda);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklStbmv(syclQueue_t device_queue, onemklUplo uplo,
+                            onemklTranspose trans, onemklDiag diag, int64_t n,
+                            int64_t k, const float *a, int64_t lda, float *x, int64_t incx) {
+    auto status = oneapi::mkl::blas::column_major::tbmv(device_queue->val, convert(uplo), convert(trans),
+                                                        convert(diag), n, k, a, lda, x, incx);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklDtbmv(syclQueue_t device_queue, onemklUplo uplo,
+                            onemklTranspose trans, onemklDiag diag, int64_t n,
+                            int64_t k, const double *a, int64_t lda, double *x, int64_t incx) {
+    auto status = oneapi::mkl::blas::column_major::tbmv(device_queue->val, convert(uplo), convert(trans),
+                                                    convert(diag), n, k, a, lda, x, incx);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklCtbmv(syclQueue_t device_queue, onemklUplo uplo,
+                            onemklTranspose trans, onemklDiag diag, int64_t n,
+                            int64_t k, const float _Complex *a, int64_t lda, float _Complex *x,
+                            int64_t incx) {
+    auto status = oneapi::mkl::blas::column_major::tbmv(device_queue->val, convert(uplo), convert(trans),
+                                            convert(diag), n, k, reinterpret_cast<const std::complex<float> *>(a),
+                                            lda, reinterpret_cast<std::complex<float> *>(x), incx);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklZtbmv(syclQueue_t device_queue, onemklUplo uplo,
+                            onemklTranspose trans, onemklDiag diag, int64_t n,
+                            int64_t k, const double _Complex *a, int64_t lda, double _Complex *x,
+                            int64_t incx) {
+    auto status = oneapi::mkl::blas::column_major::tbmv(device_queue->val, convert(uplo), convert(trans),
+                                        convert(diag), n, k, reinterpret_cast<const std::complex<double> *>(a),
+                                        lda, reinterpret_cast<std::complex<double> *>(x), incx);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+// trmv - level2
+extern "C" void onemklStrmv(syclQueue_t device_queue, onemklUplo uplo, onemklTranspose trans,
+                            onemklDiag diag, int64_t n, const float *a, int64_t lda, float *x,
+                            int64_t incx) {
+    auto status = oneapi::mkl::blas::column_major::trmv(device_queue->val, convert(uplo), convert(trans),
+                                        convert(diag), n, a, lda, x, incx);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklDtrmv(syclQueue_t device_queue, onemklUplo uplo, onemklTranspose trans,
+                            onemklDiag diag, int64_t n, const double *a, int64_t lda, double *x,
+                            int64_t incx) {
+    auto status = oneapi::mkl::blas::column_major::trmv(device_queue->val, convert(uplo), convert(trans),
+                                        convert(diag), n, a, lda, x, incx);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklCtrmv(syclQueue_t device_queue, onemklUplo uplo, onemklTranspose trans,
+                            onemklDiag diag, int64_t n, const float _Complex *a, int64_t lda, float _Complex *x,
+                            int64_t incx) {
+    auto status = oneapi::mkl::blas::column_major::trmv(device_queue->val, convert(uplo), convert(trans),
+                                        convert(diag), n, reinterpret_cast<const std::complex<float> *>(a),
+                                        lda, reinterpret_cast<std::complex<float> *>(x), incx);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklZtrmv(syclQueue_t device_queue, onemklUplo uplo, onemklTranspose trans,
+                            onemklDiag diag, int64_t n, const double _Complex *a, int64_t lda, double _Complex *x,
+                            int64_t incx) {
+    auto status = oneapi::mkl::blas::column_major::trmv(device_queue->val, convert(uplo), convert(trans),
+                                        convert(diag), n, reinterpret_cast<const std::complex<double> *>(a),
+                                        lda, reinterpret_cast<std::complex<double> *>(x), incx);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+// trsv
+extern "C" void onemklStrsv(syclQueue_t device_queue, onemklUplo uplo, onemklTranspose trans,
+                            onemklDiag diag, int64_t n, const float *a, int64_t lda, float *x,
+                            int64_t incx) {
+    auto status = oneapi::mkl::blas::column_major::trsv(device_queue->val, convert(uplo), convert(trans), 
+                                          convert(diag), n, a, lda, x, incx);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklDtrsv(syclQueue_t device_queue, onemklUplo uplo, onemklTranspose trans,
+                            onemklDiag diag, int64_t n, const double *a, int64_t lda, double *x,
+                            int64_t incx) {
+    auto status = oneapi::mkl::blas::column_major::trsv(device_queue->val, convert(uplo), convert(trans), 
+                                          convert(diag), n, a, lda, x, incx);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklCtrsv(syclQueue_t device_queue, onemklUplo uplo, onemklTranspose trans,
+                            onemklDiag diag, int64_t n, const float  _Complex *a, int64_t lda,
+                            float _Complex *x, int64_t incx) {
+    auto status = oneapi::mkl::blas::column_major::trsv(device_queue->val, convert(uplo), convert(trans), 
+                                          convert(diag), n, reinterpret_cast<const std::complex<float> *>(a),
+                                          lda, reinterpret_cast<std::complex<float> *>(x), incx);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklZtrsv(syclQueue_t device_queue, onemklUplo uplo, onemklTranspose trans,
+                            onemklDiag diag, int64_t n, const double _Complex *a, int64_t lda,
+                            double _Complex *x, int64_t incx) {
+    auto status = oneapi::mkl::blas::column_major::trsv(device_queue->val, convert(uplo), convert(trans), 
+                                          convert(diag), n, reinterpret_cast<const std::complex<double> *>(a),
+                                          lda, reinterpret_cast<std::complex<double> *>(x), incx);
+    __FORCE_MKL_FLUSH__(status);
+}
 
 extern "C" void onemklDnrm2(syclQueue_t device_queue, int64_t n, const double *x, 
                             int64_t incx, double *result) {

--- a/deps/src/onemkl.cpp
+++ b/deps/src/onemkl.cpp
@@ -87,6 +87,63 @@ extern "C" int onemklZgemm(syclQueue_t device_queue, onemklTranspose transA,
     return 0;
 }
 
+
+extern "C" void onemklSdot(syclQueue_t device_queue, int64_t n,
+                           const float *x, int64_t incx, const float *y,
+                           int64_t incy, float *result) {
+    auto status = oneapi::mkl::blas::column_major::dot(device_queue->val, n, x,
+                                                       incx, y, incy, result);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklDdot(syclQueue_t device_queue, int64_t n,
+                           const double *x, int64_t incx, const double *y,
+                           int64_t incy, double *result) {
+    auto status = oneapi::mkl::blas::column_major::dot(device_queue->val, n, x,
+                                                       incx, y, incy, result);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklCdotc(syclQueue_t device_queue, int64_t n,
+                           const float _Complex *x, int64_t incx, const float _Complex *y,
+                           int64_t incy, float _Complex *result) {
+    auto status = oneapi::mkl::blas::column_major::dotc(device_queue->val, n,
+                                                reinterpret_cast<const std::complex<float> *>(x), incx,
+                                                reinterpret_cast<const std::complex<float> *>(y), incy,
+                                                reinterpret_cast<std::complex<float> *>(result));
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklZdotc(syclQueue_t device_queue, int64_t n,
+                           const double _Complex *x, int64_t incx, const double _Complex *y,
+                           int64_t incy, double _Complex *result) {
+    auto status = oneapi::mkl::blas::column_major::dotc(device_queue->val, n,
+                                                reinterpret_cast<const std::complex<double> *>(x), incx,
+                                                reinterpret_cast<const std::complex<double> *>(y), incy,
+                                                reinterpret_cast<std::complex<double> *>(result));
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklCdotu(syclQueue_t device_queue, int64_t n,
+                           const float _Complex *x, int64_t incx, const float _Complex *y,
+                           int64_t incy, float _Complex *result) {
+    auto status = oneapi::mkl::blas::column_major::dotu(device_queue->val, n,
+                                                reinterpret_cast<const std::complex<float> *>(x), incx,
+                                                reinterpret_cast<const std::complex<float> *>(y), incy,
+                                                reinterpret_cast<std::complex<float> *>(result));
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklZdotu(syclQueue_t device_queue, int64_t n,
+                           const double _Complex *x, int64_t incx, const double _Complex *y,
+                           int64_t incy, double _Complex *result) {
+    auto status = oneapi::mkl::blas::column_major::dotu(device_queue->val, n,
+                                                reinterpret_cast<const std::complex<double> *>(x), incx,
+                                                reinterpret_cast<const std::complex<double> *>(y), incy,
+                                                reinterpret_cast<std::complex<double> *>(result));
+    __FORCE_MKL_FLUSH__(status);
+}
+
 extern "C" void onemklSasum(syclQueue_t device_queue, int64_t n, 
                             const float *x, int64_t incx,
                             float *result) {
@@ -199,6 +256,7 @@ extern "C" void onemklZdscal(syclQueue_t device_queue, int64_t n,
                                         reinterpret_cast<std::complex<double> *>(x),incx);
     __FORCE_MKL_FLUSH__(status);
 }
+
 
 extern "C" void onemklDnrm2(syclQueue_t device_queue, int64_t n, const double *x, 
                             int64_t incx, double *result) {

--- a/deps/src/onemkl.h
+++ b/deps/src/onemkl.h
@@ -15,6 +15,16 @@ typedef enum {
     ONEMLK_TRANSPOSE_CONJTRANS
 } onemklTranspose;
 
+typedef enum {
+    ONEMKL_UPLO_UPPER,
+    ONEMKL_UPLO_LOWER
+} onemklUplo;
+
+typedef enum {
+    ONEMKL_DIAG_NONUNIT,
+    ONEMKL_DIAG_UNIT
+ } onemklDiag;
+
 // XXX: how to expose half in C?
 // int onemklHgemm(syclQueue_t device_queue, onemklTranspose transA,
 //                onemklTranspose transB, int64_t m, int64_t n, int64_t k,
@@ -38,6 +48,51 @@ int onemklZgemm(syclQueue_t device_queue, onemklTranspose transA,
                 double _Complex alpha, const double _Complex *A, int64_t lda,
                 const double _Complex *B, int64_t ldb, double _Complex beta,
                 double _Complex *C, int64_t ldc);
+
+void onemklSgbmv(syclQueue_t device_queue, onemklTranspose trans, int64_t m,
+                int64_t n, int64_t kl, int64_t ku, float alpha, const float *a,
+                int64_t lda, const float *x, int64_t incx, float beta, float *y,
+                int64_t incy);
+void onemklDgbmv(syclQueue_t device_queue, onemklTranspose trans, int64_t m,
+                int64_t n, int64_t kl, int64_t ku, double alpha, const double *a,
+                int64_t lda, const double *x, int64_t incx, double beta, double *y,
+                int64_t incy);
+void onemklCgbmv(syclQueue_t device_queue, onemklTranspose trans, int64_t m,
+                int64_t n, int64_t kl, int64_t ku, float _Complex alpha, const float
+                _Complex *a, int64_t lda, const float _Complex *x, int64_t incx,
+                float _Complex beta, float _Complex *y, int64_t incy);
+void onemklZgbmv(syclQueue_t device_queue, onemklTranspose trans, int64_t m,
+                int64_t n, int64_t kl, int64_t ku, double _Complex alpha,
+                const double _Complex *a, int64_t lda, const double _Complex *x,
+                int64_t incx, double _Complex beta, double _Complex *y, int64_t incy);
+
+void onemklSgemv(syclQueue_t device_queue, onemklTranspose trans, int64_t m,
+                 int64_t n, float alpha, const float *a, int64_t lda,
+                 const float *x, int64_t incx, float beta, float *y, int64_t incy);
+void onemklDgemv(syclQueue_t device_queue, onemklTranspose trans, int64_t m,
+                 int64_t n, double alpha, const double *a, int64_t lda, 
+                 const double *x, int64_t incx, double beta, double *y, int64_t incy);
+void onemklCgemv(syclQueue_t device_queue, onemklTranspose trans, int64_t m,
+                 int64_t n, float _Complex alpha, const float _Complex *a, int64_t lda,
+                 const float _Complex *x, int64_t incx, float _Complex beta,
+                 float _Complex *y, int64_t incy);
+void onemklZgemv(syclQueue_t device_queue, onemklTranspose trans, int64_t m,
+                 int64_t n, double _Complex alpha, const double _Complex *a, int64_t lda,
+                 const double _Complex *x, int64_t incx, double _Complex beta,
+                 double _Complex *y, int64_t incy);
+
+void onemklSger(syclQueue_t device_queue, int64_t m, int64_t n, float alpha,
+                const float *x, int64_t incx, const float *y, int64_t incy, 
+                float *a, int64_t lda);
+void onemklDger(syclQueue_t device_queue, int64_t m, int64_t n, double alpha,
+                const double *x, int64_t incx, const double *y, int64_t incy, 
+                double *a, int64_t lda);
+void onemklCgerc(syclQueue_t device_queue, int64_t m, int64_t n, float _Complex alpha,
+                const float _Complex *x, int64_t incx, const float _Complex *y, int64_t incy, 
+                float _Complex *a, int64_t lda);
+void onemklZgerc(syclQueue_t device_queue, int64_t m, int64_t n, double _Complex alpha,
+                const double _Complex *x, int64_t incx, const double _Complex *y, int64_t incy, 
+                double _Complex *a, int64_t lda);
 
 void onemklSasum(syclQueue_t device_queue, int64_t n,
                 const float *x, int64_t incx, float *result);
@@ -70,6 +125,103 @@ void onemklZscal(syclQueue_t device_queue, int64_t n, double _Complex alpha,
                 double _Complex *x, int64_t incx);
 void onemklZdscal(syclQueue_t device_queue, int64_t n, double alpha, 
                 double _Complex *x, int64_t incx);
+
+void onemklChemv(syclQueue_t device_queue, onemklUplo uplo, int64_t n,
+                float _Complex alpha, const float _Complex *a, int64_t lda,
+                const float _Complex *x, int64_t incx, float _Complex beta,
+                float _Complex *y, int64_t incy);
+void onemklZhemv(syclQueue_t device_queue, onemklUplo uplo, int64_t n,
+                double _Complex alpha, const double _Complex *a, int64_t lda,
+                const double _Complex *x, int64_t incx, double _Complex beta,
+                double _Complex *y, int64_t incy);
+void onemklChbmv(syclQueue_t device_queue, onemklUplo uplo, int64_t n,
+                int64_t k, float _Complex alpha, const float _Complex *a,
+                int64_t lda, const float _Complex *x, int64_t incx, float _Complex beta,
+                float _Complex *y, int64_t incy);
+void onemklZhbmv(syclQueue_t device_queue, onemklUplo uplo, int64_t n,
+                int64_t k, double _Complex alpha, const double _Complex *a,
+                int64_t lda, const double _Complex *x, int64_t incx, double _Complex beta,
+                double _Complex *y, int64_t incy);
+void onemklCher(syclQueue_t device_queue, onemklUplo uplo, int64_t n, float alpha,
+                const float _Complex *x, int64_t incx, float _Complex *a,
+                int64_t lda);
+void onemklZher(syclQueue_t device_queue, onemklUplo uplo, int64_t n, double alpha,
+                const double _Complex *x, int64_t incx, double _Complex *a,
+                int64_t lda);
+void onemklCher2(syclQueue_t device_queue, onemklUplo uplo, int64_t n, float _Complex alpha,
+                const float _Complex *x, int64_t incx, const float _Complex *y, int64_t incy,
+                float _Complex *a, int64_t lda);
+void onemklZher2(syclQueue_t device_queue, onemklUplo uplo, int64_t n, double _Complex alpha,
+                const double _Complex *x, int64_t incx, const double _Complex *y, int64_t incy,
+                double _Complex *a, int64_t lda);
+
+void onemklSsbmv(syclQueue_t device_queue, onemklUplo uplo, int64_t n, int64_t k,
+                 float alpha, const float *a, int64_t lda, const float *x, 
+                 int64_t incx, float beta, float *y, int64_t incy);
+void onemklDsbmv(syclQueue_t device_queue, onemklUplo uplo, int64_t n, int64_t k,
+                 double alpha, const double *a, int64_t lda, const double *x, 
+                 int64_t incx, double beta, double *y, int64_t incy);
+void onemklSsymv(syclQueue_t device_queue, onemklUplo uplo, int64_t n, float alpha,
+                 const float *a, int64_t lda, const float *x, int64_t incx, float beta,
+                 float *y, int64_t incy);
+void onemklDsymv(syclQueue_t device_queue, onemklUplo uplo, int64_t n,
+                 double alpha, const double *a, int64_t lda, const double *x, 
+                 int64_t incx, double beta, double *y, int64_t incy);
+void onemklSsyr(syclQueue_t device_queue, onemklUplo uplo, int64_t n, float alpha,
+                           const float *x, int64_t incx, float *a, int64_t lda);
+void onemklDsyr(syclQueue_t device_queue, onemklUplo uplo, int64_t n, double alpha,
+                           const double *x, int64_t incx, double *a, int64_t lda);
+void onemklStbmv(syclQueue_t device_queue, onemklUplo uplo,
+                onemklTranspose trans, onemklDiag diag, int64_t n,
+                int64_t k, const float *a, int64_t lda, float *x, int64_t incx);
+
+void onemklDtbmv(syclQueue_t device_queue, onemklUplo uplo,
+                onemklTranspose trans, onemklDiag diag, int64_t n,
+                int64_t k, const double *a, int64_t lda, double *x, int64_t incx);
+
+void onemklCtbmv(syclQueue_t device_queue, onemklUplo uplo,
+                onemklTranspose trans, onemklDiag diag, int64_t n,
+                int64_t k, const float _Complex *a, int64_t lda, float _Complex *x,
+                int64_t incx);
+
+void onemklZtbmv(syclQueue_t device_queue, onemklUplo uplo,
+                onemklTranspose trans, onemklDiag diag, int64_t n,
+                int64_t k, const double _Complex *a, int64_t lda, double _Complex *x,
+                int64_t incx);
+
+void onemklStrmv(syclQueue_t device_queue, onemklUplo uplo, onemklTranspose trans,
+                onemklDiag diag, int64_t n, const float *a, int64_t lda, float *x,
+                int64_t incx);
+
+void onemklDtrmv(syclQueue_t device_queue, onemklUplo uplo, onemklTranspose trans,
+                onemklDiag diag, int64_t n, const double *a, int64_t lda, double *x,
+                int64_t incx);
+
+void onemklCtrmv(syclQueue_t device_queue, onemklUplo uplo, onemklTranspose trans,
+                onemklDiag diag, int64_t n, const float _Complex *a, int64_t lda, float _Complex *x,
+                int64_t incx);
+
+void onemklZtrmv(syclQueue_t device_queue, onemklUplo uplo, onemklTranspose trans,
+                onemklDiag diag, int64_t n, const double _Complex *a, int64_t lda, double _Complex *x,
+                int64_t incx);
+
+// trsv
+void onemklStrsv(syclQueue_t device_queue, onemklUplo uplo, onemklTranspose trans,
+                onemklDiag diag, int64_t n, const float *a, int64_t lda, float *x,
+                int64_t incx);
+
+void onemklDtrsv(syclQueue_t device_queue, onemklUplo uplo, onemklTranspose trans,
+                onemklDiag diag, int64_t n, const double *a, int64_t lda, double *x,
+                int64_t incx);
+
+void onemklCtrsv(syclQueue_t device_queue, onemklUplo uplo, onemklTranspose trans,
+                onemklDiag diag, int64_t n, const float _Complex *a, int64_t lda, float _Complex *x,
+                int64_t incx);
+
+void onemklZtrsv(syclQueue_t device_queue, onemklUplo uplo, onemklTranspose trans,
+                onemklDiag diag, int64_t n, const double _Complex *a, int64_t lda, double _Complex *x,
+                int64_t incx);
+
 // Supported Level-1: Nrm2
 void onemklDnrm2(syclQueue_t device_queue, int64_t n, const double *x, 
                  int64_t incx, double *result);
@@ -82,22 +234,17 @@ void onemklZnrm2(syclQueue_t device_queue, int64_t n, const double _Complex *x,
 
 void onemklSdot(syclQueue_t device_queue, int64_t n, const float *x,
                 int64_t incx, const float *y, int64_t incy, float *result);
-
 void onemklDdot(syclQueue_t device_queue, int64_t n, const double *x,
                 int64_t incx, const double *y, int64_t incy, double *result);
-
 void onemklCdotc(syclQueue_t device_queue, int64_t n, const float _Complex *x,
                 int64_t incx, const float _Complex *y, int64_t incy,
                 float _Complex *result);
-
 void onemklZdotc(syclQueue_t device_queue, int64_t n, const double _Complex *x,
                 int64_t incx, const double _Complex *y, int64_t incy,
                 double _Complex *result);
-
 void onemklCdotu(syclQueue_t device_queue, int64_t n, const float _Complex *x,
                 int64_t incx, const float _Complex *y, int64_t incy,
                 float _Complex *result);
-
 void onemklZdotu(syclQueue_t device_queue, int64_t n, const double _Complex *x,
                 int64_t incx, const double _Complex *y, int64_t incy,
                 double _Complex *result);

--- a/deps/src/onemkl.h
+++ b/deps/src/onemkl.h
@@ -80,6 +80,28 @@ void onemklCnrm2(syclQueue_t device_queue, int64_t n, const float _Complex *x,
 void onemklZnrm2(syclQueue_t device_queue, int64_t n, const double _Complex *x, 
                  int64_t incx, double *result);
 
+void onemklSdot(syclQueue_t device_queue, int64_t n, const float *x,
+                int64_t incx, const float *y, int64_t incy, float *result);
+
+void onemklDdot(syclQueue_t device_queue, int64_t n, const double *x,
+                int64_t incx, const double *y, int64_t incy, double *result);
+
+void onemklCdotc(syclQueue_t device_queue, int64_t n, const float _Complex *x,
+                int64_t incx, const float _Complex *y, int64_t incy,
+                float _Complex *result);
+
+void onemklZdotc(syclQueue_t device_queue, int64_t n, const double _Complex *x,
+                int64_t incx, const double _Complex *y, int64_t incy,
+                double _Complex *result);
+
+void onemklCdotu(syclQueue_t device_queue, int64_t n, const float _Complex *x,
+                int64_t incx, const float _Complex *y, int64_t incy,
+                float _Complex *result);
+
+void onemklZdotu(syclQueue_t device_queue, int64_t n, const double _Complex *x,
+                int64_t incx, const double _Complex *y, int64_t incy,
+                double _Complex *result);
+
 void onemklDcopy(syclQueue_t device_queue, int64_t n, const double *x,
                  int64_t incx, double *y, int64_t incy);
 void onemklScopy(syclQueue_t device_queue, int64_t n, const float *x,

--- a/lib/mkl/libonemkl.jl
+++ b/lib/mkl/libonemkl.jl
@@ -6,6 +6,44 @@ using CEnum
     ONEMLK_TRANSPOSE_CONJTRANS = 2
 end
 
+@cenum onemklUplo::UInt32 begin
+    ONEMKL_UPLO_UPPER = 0
+    ONEMKL_UPLO_LOWER = 1
+end
+
+@cenum onemklDiag::UInt32 begin
+    ONEMKL_DIAG_NONUNIT = 0
+    ONEMKL_DIAG_UNIT = 1
+end
+
+function onemklSgbmv(device_queue, trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y, incy)
+    @ccall liboneapi_support.onemklSgbmv(device_queue::syclQueue_t, trans::onemklTranspose, 
+                                        m::Int64, n::Int64, kl::Int64, ku::Int64, alpha::Cfloat,
+                                        a::ZePtr{Cfloat}, lda::Int64, x::ZePtr{Cfloat}, incx::Int64,
+                                        beta::Cfloat, y::ZePtr{Cfloat}, incy::Int64)::Cvoid
+end
+
+function onemklDgbmv(device_queue, trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y, incy)
+    @ccall liboneapi_support.onemklDgbmv(device_queue::syclQueue_t, trans::onemklTranspose, 
+                                        m::Int64, n::Int64, kl::Int64, ku::Int64, alpha::Cdouble,
+                                        a::ZePtr{Cdouble}, lda::Int64, x::ZePtr{Cdouble}, incx::Int64,
+                                        beta::Cdouble, y::ZePtr{Cdouble}, incy::Int64)::Cvoid
+end
+
+function onemklCgbmv(device_queue, trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y, incy)
+    @ccall liboneapi_support.onemklCgbmv(device_queue::syclQueue_t, trans::onemklTranspose, 
+                                        m::Int64, n::Int64, kl::Int64, ku::Int64, alpha::ComplexF32,
+                                        a::ZePtr{ComplexF32}, lda::Int64, x::ZePtr{ComplexF32}, incx::Int64,
+                                        beta::ComplexF32, y::ZePtr{ComplexF32}, incy::Int64)::Cvoid
+end
+
+function onemklZgbmv(device_queue, trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y, incy)
+    @ccall liboneapi_support.onemklZgbmv(device_queue::syclQueue_t, trans::onemklTranspose, 
+                                        m::Int64, n::Int64, kl::Int64, ku::Int64, alpha::ComplexF64,
+                                        a::ZePtr{ComplexF64}, lda::Int64, x::ZePtr{ComplexF64}, incx::Int64,
+                                        beta::ComplexF64, y::ZePtr{ComplexF64}, incy::Int64)::Cvoid
+end
+
 function onemklSgemm(device_queue, transA, transB, m, n, k, alpha, A, lda, B, ldb, beta, C,
                      ldc)
     @ccall liboneapi_support.onemklSgemm(device_queue::syclQueue_t, transA::onemklTranspose,
@@ -150,6 +188,232 @@ end
 function onemklCsscal(device_queue, n, alpha, x, incx)
 	@ccall liboneapi_support.onemklCsscal(device_queue::syclQueue_t, n::Int64, 
                                         alpha::Cfloat, x::ZePtr{ComplexF32}, incx::Int64)::Cvoid
+end
+
+function onemklSgemv(device_queue, trans, m, n, alpha, a, lda, x, incx, beta, y, incy)
+    @ccall liboneapi_support.onemklSgemv(device_queue::syclQueue_t, trans::onemklTranspose,
+                                        m::Int64, n::Int64, alpha::Cfloat, a::ZePtr{Cfloat},
+                                        lda::Int64, x::ZePtr{Cfloat}, incx::Int64, beta::Cfloat,
+                                        y::ZePtr{Cfloat}, incy::Int64)::Cvoid
+end
+
+function onemklDgemv(device_queue, trans, m, n, alpha, a, lda, x, incx, beta, y, incy)
+    @ccall liboneapi_support.onemklDgemv(device_queue::syclQueue_t, trans::onemklTranspose,
+                                        m::Int64, n::Int64, alpha::Cdouble, a::ZePtr{Cdouble},
+                                        lda::Int64, x::ZePtr{Cdouble}, incx::Int64, beta::Cdouble,
+                                        y::ZePtr{Cdouble}, incy::Int64)::Cvoid
+end
+
+function onemklCgemv(device_queue, trans, m, n, alpha, a, lda, x, incx, beta, y, incy)
+    @ccall liboneapi_support.onemklCgemv(device_queue::syclQueue_t, trans::onemklTranspose,
+                                        m::Int64, n::Int64, alpha::ComplexF32, a::ZePtr{ComplexF32},
+                                        lda::Int64, x::ZePtr{ComplexF32}, incx::Int64, beta::ComplexF32,
+                                        y::ZePtr{ComplexF32}, incy::Int64)::Cvoid
+end
+
+function onemklZgemv(device_queue, trans, m, n, alpha, a, lda, x, incx, beta, y, incy)
+    @ccall liboneapi_support.onemklZgemv(device_queue::syclQueue_t, trans::onemklTranspose,
+                                        m::Int64, n::Int64, alpha::ComplexF64, a::ZePtr{ComplexF64},
+                                        lda::Int64, x::ZePtr{ComplexF64}, incx::Int64, beta::ComplexF64,
+                                        y::ZePtr{ComplexF64}, incy::Int64)::Cvoid
+end
+
+function onemklSger(device_queue, m, n, alpha, x, incx, y, incy, a, lda)
+    @ccall liboneapi_support.onemklSger(device_queue::syclQueue_t, m::Int64, n::Int64,
+                                        alpha::Cfloat, x::ZePtr{Cfloat}, incx::Int64,
+                                        y::ZePtr{Cfloat}, incy::Int64, a::ZePtr{Cfloat},
+                                        lda::Int64)::Cvoid
+end
+
+function onemklDger(device_queue, m, n, alpha, x, incx, y, incy, a, lda)
+    @ccall liboneapi_support.onemklDger(device_queue::syclQueue_t, m::Int64, n::Int64,
+                                        alpha::Cdouble, x::ZePtr{Cdouble}, incx::Int64,
+                                        y::ZePtr{Cdouble}, incy::Int64, a::ZePtr{Cdouble},
+                                        lda::Int64)::Cvoid
+end
+
+function onemklCgerc(device_queue, m, n, alpha, x, incx, y, incy, a, lda)
+    @ccall liboneapi_support.onemklCgerc(device_queue::syclQueue_t, m::Int64, n::Int64,
+                                        alpha::ComplexF32, x::ZePtr{ComplexF32}, incx::Int64,
+                                        y::ZePtr{ComplexF32}, incy::Int64, a::ZePtr{ComplexF32},
+                                        lda::Int64)::Cvoid
+end
+
+function onemklZgerc(device_queue, m, n, alpha, x, incx, y, incy, a, lda)
+    @ccall liboneapi_support.onemklZgerc(device_queue::syclQueue_t, m::Int64, n::Int64,
+                                        alpha::ComplexF64, x::ZePtr{ComplexF64}, incx::Int64,
+                                        y::ZePtr{ComplexF64}, incy::Int64, a::ZePtr{ComplexF64},
+                                        lda::Int64)::Cvoid
+end
+
+function onemklChemv(device_queue, uplo, n, alpha, a, lda, x, incx, beta, y, incy)
+    @ccall liboneapi_support.onemklChemv(device_queue::syclQueue_t, uplo::onemklUplo,
+                                         n::Int64, alpha::ComplexF32, a::ZePtr{ComplexF32},
+                                         lda::Int64, x::ZePtr{ComplexF32}, incx::Int64,
+                                         beta::ComplexF32, y::ZePtr{ComplexF32}, incy::Int64)::Cvoid
+end
+
+function onemklZhemv(device_queue, uplo, n, alpha, a, lda, x, incx, beta, y, incy)
+    @ccall liboneapi_support.onemklZhemv(device_queue::syclQueue_t, uplo::onemklUplo,
+                                         n::Int64, alpha::ComplexF64, a::ZePtr{ComplexF64},
+                                         lda::Int64, x::ZePtr{ComplexF64}, incx::Int64,
+                                         beta::ComplexF64, y::ZePtr{ComplexF64}, incy::Int64)::Cvoid
+end
+
+function onemklChbmv(device_queue, uplo, n, k, alpha, a, lda, x, incx, beta, y, incy)
+    @ccall liboneapi_support.onemklChbmv(device_queue::syclQueue_t, uplo::onemklUplo,
+                                         n::Int64, k::Int64, alpha::ComplexF32, a::ZePtr{ComplexF32},
+                                         lda::Int64, x::ZePtr{ComplexF32}, incx::Int64, beta::ComplexF32,
+                                         y::ZePtr{ComplexF32}, incy::Int64)::Cvoid
+end
+
+function onemklZhbmv(device_queue, uplo, n, k, alpha, a, lda, x, incx, beta, y, incy)
+    @ccall liboneapi_support.onemklZhbmv(device_queue::syclQueue_t, uplo::onemklUplo,
+                                         n::Int64, k::Int64, alpha::ComplexF64, a::ZePtr{ComplexF64},
+                                         lda::Int64, x::ZePtr{ComplexF64}, incx::Int64, beta::ComplexF64,
+                                         y::ZePtr{ComplexF64}, incy::Int64)::Cvoid
+end
+
+function onemklCher(device_queue, uplo, n, alpha, x, incx, a, lda)
+    @ccall liboneapi_support.onemklCher(device_queue::syclQueue_t, uplo::onemklUplo,
+                                        n::Int64, alpha::ComplexF32, x::ZePtr{ComplexF32},
+                                        incx::Int64, a::ZePtr{ComplexF32}, lda::Int64)::Cvoid
+end
+
+function onemklZher(device_queue, uplo, n, alpha, x, incx, a, lda)
+    @ccall liboneapi_support.onemklZher(device_queue::syclQueue_t, uplo::onemklUplo,
+                                        n::Int64, alpha::ComplexF64, x::ZePtr{ComplexF64},
+                                        incx::Int64, a::ZePtr{ComplexF64}, lda::Int64)::Cvoid
+end
+
+function onemklCher2(device_queue, uplo, n, alpha, x, incx, y, incy, a, lda)
+    @ccall liboneapi_support.onemklCher2(device_queue::syclQueue_t, uplo::onemklUplo,
+                                         n::Int64, alpha::ComplexF32, x::ZePtr{ComplexF32},
+                                         incx::Int64, y::ZePtr{ComplexF32}, incy::Int64,
+                                         a::ZePtr{ComplexF32}, lda::Int64)::Cvoid
+end
+
+function onemklZher2(device_queue, uplo, n, alpha, x, incx, y, incy, a, lda)
+    @ccall liboneapi_support.onemklZher2(device_queue::syclQueue_t, uplo::onemklUplo,
+                                         n::Int64, alpha::ComplexF64, x::ZePtr{ComplexF64},
+                                         incx::Int64, y::ZePtr{ComplexF64}, incy::Int64,
+                                         a::ZePtr{ComplexF64}, lda::Int64)::Cvoid
+end
+
+function onemklSsbmv(device_queue, uplo, n, k, alpha, a, lda, x, incx, beta, y, incy)
+    @ccall liboneapi_support.onemklSsbmv(device_queue::syclQueue_t, uplo::onemklUplo,
+                                         n::Int64, k::Int64, alpha::Cfloat, a::ZePtr{Cfloat},
+                                         lda::Int64, x::ZePtr{Cfloat}, incx::Int64, beta::Cfloat,
+                                         y::ZePtr{Cfloat}, incy::Int64)::Cvoid
+end
+
+function onemklDsbmv(device_queue, uplo, n, k, alpha, a, lda, x, incx, beta, y, incy)
+    @ccall liboneapi_support.onemklDsbmv(device_queue::syclQueue_t, uplo::onemklUplo,
+                                         n::Int64, k::Int64, alpha::Cdouble, a::ZePtr{Cdouble},
+                                         lda::Int64, x::ZePtr{Cdouble}, incx::Int64, beta::Cdouble,
+                                         y::ZePtr{Cdouble}, incy::Int64)::Cvoid
+end
+
+function onemklSsymv(device_queue, uplo, n, alpha, a, lda, x, incx, beta, y, incy)
+    @ccall liboneapi_support.onemklSsymv(device_queue::syclQueue_t, uplo::onemklUplo,
+                                         n::Int64, alpha::Cfloat, a::ZePtr{Cfloat},
+                                         lda::Int64, x::ZePtr{Cfloat}, incx::Int64, beta::Cfloat,
+                                         y::ZePtr{Cfloat}, incy::Int64)::Cvoid
+end
+
+function onemklDsymv(device_queue, uplo, n, alpha, a, lda, x, incx, beta, y, incy)
+    @ccall liboneapi_support.onemklDsymv(device_queue::syclQueue_t, uplo::onemklUplo,
+                                         n::Int64, alpha::Cdouble, a::ZePtr{Cdouble},
+                                         lda::Int64, x::ZePtr{Cdouble}, incx::Int64, beta::Cdouble,
+                                         y::ZePtr{Cdouble}, incy::Int64)::Cvoid
+end
+
+function onemklSsyr(device_queue, uplo, n, alpha, x, incx, a, lda)
+    @ccall liboneapi_support.onemklSsyr(device_queue::syclQueue_t, uplo::onemklUplo,
+                                        n::Int64, alpha::Cfloat, x::ZePtr{Cfloat}, 
+                                        incx::Int64, a::ZePtr{Cfloat}, lda::Int64)::Cvoid
+end
+
+function onemklDsyr(device_queue, uplo, n, alpha, x, incx, a, lda)
+    @ccall liboneapi_support.onemklDsyr(device_queue::syclQueue_t, uplo::onemklUplo,
+                                        n::Int64, alpha::Cdouble, x::ZePtr{Cdouble}, 
+                                        incx::Int64, a::ZePtr{Cdouble}, lda::Int64)::Cvoid
+end
+
+function onemklStbmv(device_queue, uplo, trans, diag, n, k, a, lda, x, incx)
+    @ccall liboneapi_support.onemklStbmv(device_queue::syclQueue_t, uplo::onemklUplo,
+                                         trans::onemklTranspose, diag::onemklDiag, n::Int64,
+                                         k::Int64, a::ZePtr{Cfloat}, lda::Int64, x::ZePtr{Cfloat},
+                                         incx::Int64)::Cvoid
+end
+
+function onemklDtbmv(device_queue, uplo, trans, diag, n, k, a, lda, x, incx)
+    @ccall liboneapi_support.onemklDtbmv(device_queue::syclQueue_t, uplo::onemklUplo,
+                                         trans::onemklTranspose, diag::onemklDiag, n::Int64,
+                                         k::Int64, a::ZePtr{Cdouble}, lda::Int64, x::ZePtr{Cdouble},
+                                         incx::Int64)::Cvoid
+end
+
+function onemklCtbmv(device_queue, uplo, trans, diag, n, k, a, lda, x, incx)
+    @ccall liboneapi_support.onemklCtbmv(device_queue::syclQueue_t, uplo::onemklUplo,
+                                         trans::onemklTranspose, diag::onemklDiag, n::Int64,
+                                         k::Int64, a::ZePtr{ComplexF32}, lda::Int64, x::ZePtr{ComplexF32},
+                                         incx::Int64)::Cvoid
+end
+
+function onemklZtbmv(device_queue, uplo, trans, diag, n, k, a, lda, x, incx)
+    @ccall liboneapi_support.onemklZtbmv(device_queue::syclQueue_t, uplo::onemklUplo,
+                                         trans::onemklTranspose, diag::onemklDiag, n::Int64,
+                                         k::Int64, a::ZePtr{ComplexF64}, lda::Int64, x::ZePtr{ComplexF64},
+                                         incx::Int64)::Cvoid
+end
+
+function onemklStrmv(device_queue, uplo, trans, diag, n, a, lda, x, incx)
+    @ccall liboneapi_support.onemklStrmv(device_queue::syclQueue_t, uplo::onemklUplo,
+                                         trans::onemklTranspose, diag::onemklDiag, n::Int64,
+                                         a::ZePtr{Cfloat}, lda::Int64, x::ZePtr{Cfloat}, incx::Int64)::Cvoid
+end
+
+function onemklDtrmv(device_queue, uplo, trans, diag, n, a, lda, x, incx)
+    @ccall liboneapi_support.onemklDtrmv(device_queue::syclQueue_t, uplo::onemklUplo,
+                                         trans::onemklTranspose, diag::onemklDiag, n::Int64,
+                                         a::ZePtr{Cdouble}, lda::Int64, x::ZePtr{Cdouble}, incx::Int64)::Cvoid
+end
+
+function onemklCtrmv(device_queue, uplo, trans, diag, n, a, lda, x, incx)
+    @ccall liboneapi_support.onemklCtrmv(device_queue::syclQueue_t, uplo::onemklUplo,
+                                         trans::onemklTranspose, diag::onemklDiag, n::Int64,
+                                         a::ZePtr{ComplexF32}, lda::Int64, x::ZePtr{ComplexF32}, incx::Int64)::Cvoid
+end
+
+function onemklZtrmv(device_queue, uplo, trans, diag, n, a, lda, x, incx)
+    @ccall liboneapi_support.onemklZtrmv(device_queue::syclQueue_t, uplo::onemklUplo,
+                                         trans::onemklTranspose, diag::onemklDiag, n::Int64,
+                                         a::ZePtr{ComplexF64}, lda::Int64, x::ZePtr{ComplexF64}, incx::Int64)::Cvoid
+end
+
+function onemklStrsv(device_queue, uplo, trans, diag, n, a, lda, x, incx)
+    @ccall liboneapi_support.onemklStrsv(device_queue::syclQueue_t, uplo::onemklUplo,
+                                         trans::onemklTranspose, diag::onemklDiag, n::Int64,
+                                         a::ZePtr{Cfloat}, lda::Int64, x::ZePtr{Cfloat}, incx::Int64)::Cvoid
+end
+
+function onemklDtrsv(device_queue, uplo, trans, diag, n, a, lda, x, incx)
+    @ccall liboneapi_support.onemklDtrsv(device_queue::syclQueue_t, uplo::onemklUplo,
+                                         trans::onemklTranspose, diag::onemklDiag, n::Int64,
+                                         a::ZePtr{Cdouble}, lda::Int64, x::ZePtr{Cdouble}, incx::Int64)::Cvoid
+end
+
+function onemklCtrsv(device_queue, uplo, trans, diag, n, a, lda, x, incx)
+    @ccall liboneapi_support.onemklCtrsv(device_queue::syclQueue_t, uplo::onemklUplo,
+                                         trans::onemklTranspose, diag::onemklDiag, n::Int64,
+                                         a::ZePtr{ComplexF32}, lda::Int64, x::ZePtr{ComplexF32}, incx::Int64)::Cvoid
+end
+
+function onemklZtrsv(device_queue, uplo, trans, diag, n, a, lda, x, incx)
+    @ccall liboneapi_support.onemklZtrsv(device_queue::syclQueue_t, uplo::onemklUplo,
+                                         trans::onemklTranspose, diag::onemklDiag, n::Int64,
+                                         a::ZePtr{ComplexF64}, lda::Int64, x::ZePtr{ComplexF64}, incx::Int64)::Cvoid
 end
 
 function onemklDnrm2(device_queue, n, x, incx, result)

--- a/lib/mkl/libonemkl.jl
+++ b/lib/mkl/libonemkl.jl
@@ -42,6 +42,42 @@ function onemklZgemm(device_queue, transA, transB, m, n, k, alpha, A, lda, B, ld
                                     C::ZePtr{ComplexF64}, ldc::Int64)::Cint
 end
 
+function onemklSdot(device_queue, n, x, incx, y, incy, result)
+    @ccall liboneapi_support.onemklSdot(device_queue::syclQueue_t, n::Int64,
+                                        x::ZePtr{Cfloat}, incx::Int64, y::ZePtr{Cfloat},
+                                        incy::Int64, result::RefOrZeRef{Cfloat})::Cvoid
+end
+
+function onemklDdot(device_queue, n, x, incx, y, incy, result)
+    @ccall liboneapi_support.onemklDdot(device_queue::syclQueue_t, n::Int64,
+                                        x::ZePtr{Cdouble}, incx::Int64, y::ZePtr{Cdouble},
+                                        incy::Int64, result::RefOrZeRef{Cdouble})::Cvoid
+end
+
+function onemklCdotc(device_queue, n, x, incx, y, incy, result)
+    @ccall liboneapi_support.onemklCdotc(device_queue::syclQueue_t, n::Int64,
+                                        x::ZePtr{ComplexF32}, incx::Int64, y::ZePtr{ComplexF32},
+                                        incy::Int64, result::RefOrZeRef{ComplexF32})::Cvoid
+end
+
+function onemklZdotc(device_queue, n, x, incx, y, incy, result)
+    @ccall liboneapi_support.onemklZdotc(device_queue::syclQueue_t, n::Int64,
+                                        x::ZePtr{ComplexF64}, incx::Int64, y::ZePtr{ComplexF64},
+                                        incy::Int64, result::RefOrZeRef{ComplexF64})::Cvoid
+end
+
+function onemklCdotu(device_queue, n, x, incx, y, incy, result)
+    @ccall liboneapi_support.onemklCdotu(device_queue::syclQueue_t, n::Int64,
+                                        x::ZePtr{ComplexF32}, incx::Int64, y::ZePtr{ComplexF32},
+                                        incy::Int64, result::RefOrZeRef{ComplexF32})::Cvoid
+end
+
+function onemklZdotu(device_queue, n, x, incx, y, incy, result)
+    @ccall liboneapi_support.onemklZdotu(device_queue::syclQueue_t, n::Int64,
+                                        x::ZePtr{ComplexF64}, incx::Int64, y::ZePtr{ComplexF64},
+                                        incy::Int64, result::RefOrZeRef{ComplexF64})::Cvoid
+end
+
 function onemklSasum(device_queue, n, x, incx, result)
     @ccall liboneapi_support.onemklSasum(device_queue::syclQueue_t, n::Int64,
                                         x::ZePtr{Cfloat}, incx::Int64,
@@ -115,6 +151,7 @@ function onemklCsscal(device_queue, n, alpha, x, incx)
 	@ccall liboneapi_support.onemklCsscal(device_queue::syclQueue_t, n::Int64, 
                                         alpha::Cfloat, x::ZePtr{ComplexF32}, incx::Int64)::Cvoid
 end
+
 function onemklDnrm2(device_queue, n, x, incx, result)
 	@ccall liboneapi_support.onemklDnrm2(device_queue::syclQueue_t, 
                                 n::Int64, x::ZePtr{Cdouble}, incx::Int64, 

--- a/lib/mkl/linalg.jl
+++ b/lib/mkl/linalg.jl
@@ -76,6 +76,76 @@ function LinearAlgebra.dot(x::oneStridedArray{T}, y::oneStridedArray{T}) where T
     oneMKL.dotc(n, x, y)
 end
 
+@inline function LinearAlgebra.mul!(y::oneStridedVecOrMat{T}, A::Hermitian{T,<:oneStridedVecOrMat}, x::oneStridedVecOrMat{T},
+             α::Number, β::Number) where {T<:Union{ComplexF32,ComplexF64}}
+    alpha, beta = promote(α, β, zero(T))
+    if alpha isa Union{Bool,T} && beta isa Union{Bool,T}
+        return oneMKL.hemv!(A.uplo, alpha, A.data, x, beta, y)
+    else
+        error("only supports BLAS type, got $T")
+    end
+end
+
+# symmetric mul!
+# level 2
+@inline function LinearAlgebra.mul!(y::oneStridedVecOrMat{T}, A::Hermitian{T,<:oneStridedVecOrMat}, x::oneStridedVecOrMat{T},
+             α::Number, β::Number) where {T<:Union{Float32,Float64}}
+    alpha, beta = promote(α, β, zero(T))
+    if alpha isa Union{Bool,T} && beta isa Union{Bool,T}
+        return oneMKL.symv!(A.uplo, alpha, A.data, x, beta, y)
+    else
+        error("only supports BLAS type, got $T")
+    end
+end
+
+## direct multiplication/division
+for (t, uploc, isunitc) in ((:LowerTriangular, 'L', 'N'),
+                            (:UnitLowerTriangular, 'L', 'U'),
+                            (:UpperTriangular, 'U', 'N'),
+                            (:UnitUpperTriangular, 'U', 'U'))
+    @eval begin
+        # Multiplication
+        LinearAlgebra.lmul!(A::$t{T,<:oneStridedVecOrMat},
+                            b::oneStridedVecOrMat{T}) where {T<:onemklFloat} =
+            oneMKL.trmv!($uploc, 'N', $isunitc, parent(A), b)
+
+        # Left division
+        LinearAlgebra.ldiv!(A::$t{T,<:oneStridedVecOrMat},
+                            B::oneStridedVecOrMat{T}) where {T<:onemklFloat} =
+            oneMKL.trsv!($uploc, 'N', $isunitc, parent(A), B)
+    end
+end
+
+## adjoint/transpose multiplication ('uploc' reversed)
+for (t, uploc, isunitc) in ((:LowerTriangular, 'U', 'N'),
+                            (:UnitLowerTriangular, 'U', 'U'),
+                            (:UpperTriangular, 'L', 'N'),
+                            (:UnitUpperTriangular, 'L', 'U'))
+    @eval begin
+        # Multiplication
+        LinearAlgebra.lmul!(A::$t{<:Any,<:Transpose{T,<:oneStridedMatrix}},
+                            b::oneStridedVector{T}) where {T<:onemklFloat} =
+            oneMKL.trmv!($uploc, 'T', $isunitc, parent(parent(A)), b)
+        LinearAlgebra.lmul!(A::$t{<:Any,<:Adjoint{T,<:oneStridedMatrix}},
+                            b::oneStridedVector{T}) where {T<:Union{Float32,Float64}} =
+            oneMKL.trmv!($uploc, 'T', $isunitc, parent(parent(A)), b)
+        LinearAlgebra.lmul!(A::$t{<:Any,<:Adjoint{T,<:oneStridedMatrix}},
+                            b::oneStridedVector{T}) where {T<:Union{ComplexF32,ComplexF64}} =
+            oneMKL.trmv!($uploc, 'C', $isunitc, parent(parent(A)), b)
+
+        # Left division
+        LinearAlgebra.ldiv!(A::$t{<:Any,<:Transpose{T,<:oneStridedMatrix}},
+                            B::oneStridedVector{T}) where {T<:onemklFloat} =
+            oneMKL.trsv!($uploc, 'T', $isunitc, parent(parent(A)), B)
+        LinearAlgebra.ldiv!(A::$t{<:Any,<:Adjoint{T,<:oneStridedMatrix}},
+                            B::oneStridedVector{T}) where {T<:Union{Float32,Float64}} =
+            oneMKL.trsv!($uploc, 'T', $isunitc, parent(parent(A)), B)
+        LinearAlgebra.ldiv!(A::$t{<:Any,<:Adjoint{T,<:oneStridedMatrix}},
+                            B::oneStridedVector{T}) where {T<:Union{ComplexF32,ComplexF64}} =
+            oneMKL.trsv!($uploc, 'C', $isunitc, parent(parent(A)), B)
+    end
+end
+
 for NT in (Number, Real)
     # NOTE: alpha/beta also ::Real to avoid ambiguities with certain Base methods
     @eval begin

--- a/lib/mkl/linalg.jl
+++ b/lib/mkl/linalg.jl
@@ -64,6 +64,18 @@ LinearAlgebra.rmul!(x::oneStridedVecOrMat{<:onemklFloat}, k::Real) =
 	invoke(rmul!, Tuple{typeof(x), Number}, x, k)
 LinearAlgebra.norm(x::oneStridedVecOrMat{<:onemklFloat}) = oneMKL.nrm2(length(x), x)
 
+function LinearAlgebra.dot(x::oneStridedArray{T}, y::oneStridedArray{T}) where T<:Union{Float32, Float64}
+    n = length(x)
+    n == length(y) || throw(DimensionMismatch("dot product arguments have lengths $(length(x)) and $(length(y))"))
+    oneMKL.dot(n, x, y)
+end
+
+function LinearAlgebra.dot(x::oneStridedArray{T}, y::oneStridedArray{T}) where T<:Union{ComplexF32, ComplexF64}
+    n = length(x)
+    n == length(y) || throw(DimensionMismatch("dot product arguments have lengths $(length(x)) and $(length(y))"))
+    oneMKL.dotc(n, x, y)
+end
+
 for NT in (Number, Real)
     # NOTE: alpha/beta also ::Real to avoid ambiguities with certain Base methods
     @eval begin

--- a/lib/mkl/oneMKL.jl
+++ b/lib/mkl/oneMKL.jl
@@ -18,4 +18,35 @@ const onemklFloat = Union{Float64,Float32,ComplexF64,ComplexF32}
 include("wrappers.jl")
 include("linalg.jl")
 
+function band(A::StridedArray, kl, ku)
+    m, n = size(A)
+    AB = zeros(eltype(A),kl+ku+1,n)
+    for j = 1:n
+        for i = max(1,j-ku):min(m,j+kl)
+            AB[ku+1-j+i,j] = A[i,j]
+        end
+    end
+    return AB
+end
+
+# convert band storage to general matrix
+function unband(AB::StridedArray,m,kl,ku)
+    bm, n = size(AB)
+    A = zeros(eltype(AB),m,n)
+    for j = 1:n
+        for i = max(1,j-ku):min(m,j+kl)
+            A[i,j] = AB[ku+1-j+i,j]
+        end
+    end
+    return A
+end
+
+# zero out elements not on matrix bands
+function bandex(A::AbstractMatrix,kl,ku)
+    m, n = size(A)
+    AB = band(A,kl,ku)
+    B = unband(AB,m,kl,ku)
+    return B
+end
+
 end

--- a/lib/mkl/wrappers.jl
+++ b/lib/mkl/wrappers.jl
@@ -68,6 +68,27 @@ for (fname, elty, ret_type) in
     end
 end
 
+## dot
+for (jname, fname, elty) in
+        ((:dot, :onemklSdot,:Float32),
+         (:dot, :onemklDdot,:Float64),
+         (:dotc, :onemklCdotc, :ComplexF32),
+         (:dotc, :onemklZdotc, :ComplexF64),
+         (:dotu, :onemklCdotu, :ComplexF32),
+         (:dotu, :onemklZdotu, :ComplexF64))
+    @eval begin
+        function $jname(n::Integer,
+                         x::oneStridedArray{$elty},
+                         y::oneStridedArray{$elty})
+            queue = global_queue(context(x), device(x))
+            result = oneArray{$elty}([0]);
+            $fname(sycl_queue(queue), n, x, stride(x,1), y, stride(y,1), result)
+            res = Array(result)
+            return res[1]
+        end
+    end
+end
+
 for (fname, elty, celty) in ((:onemklCsscal, :Float32, :ComplexF32),
                              (:onemklZdscal, :Float64, :ComplexF64))
     @eval begin
@@ -79,6 +100,7 @@ for (fname, elty, celty) in ((:onemklCsscal, :Float32, :ComplexF32),
         end
     end
 end
+
 #
 # BLAS
 #

--- a/test/onemkl.jl
+++ b/test/onemkl.jl
@@ -1,9 +1,11 @@
 using oneAPI
-using oneAPI.oneMKL
+using oneAPI.oneMKL: band, bandex
 
 using LinearAlgebra
 
 m = 20
+n = 35
+k = 13
 
 ############################################################################################
 @testset "level 1" begin
@@ -74,6 +76,446 @@ m = 20
         @testset "asum" begin
             @test testf(BLAS.asum, rand(T,m))
 
+        end
+    end
+end
+
+@testset "level 2" begin
+    @testset for T in intersect(eltypes, [Float32, Float64, ComplexF32, ComplexF64])
+        alpha = rand(T)
+        beta = rand(T)
+
+        @testset "gemv" begin
+            @test testf(*, rand(T, m, n), rand(T, n))
+            @test testf(*, transpose(rand(T, m, n)), rand(T, m))
+            @test testf(*, rand(T, m, n)', rand(T, m))
+            x = rand(T, m)
+            A = rand(T, m, m + 1 )
+            y = rand(T, m)
+            dx = oneArray(x)
+            dA = oneArray(A)
+            dy = oneArray(y)
+            @test_throws DimensionMismatch mul!(dy, dA, dx)
+            A = rand(T, m + 1, m )
+            dA = oneArray(A)
+            @test_throws DimensionMismatch mul!(dy, dA, dx)
+            x = rand(T, m)
+            A = rand(T, n, m)
+            dx = oneArray(x)
+            dA = oneArray(A)
+            alpha = rand(T)
+            dy = oneMKL.gemv('N', alpha, dA, dx)
+            hy = collect(dy)
+            @test hy ≈ alpha * A * x
+            dy = oneMKL.gemv('N', dA, dx)
+            hy = collect(dy)
+            @test hy ≈ A * x
+        end
+
+        @testset "banded methods" begin
+            # bands
+            ku = 2
+            kl = 3
+            # generate banded matrix
+            A = rand(T, m,n)
+            A = bandex(A, kl, ku)
+
+            # get packed format
+            Ab = band(A, kl, ku)
+            d_Ab = oneArray(Ab)
+            x = rand(T, n)
+            d_x = oneArray(x)
+
+            @testset "gbmv!" begin
+                # Test: y = alpha * A * x + beta * y
+                y = rand(T, m)
+                d_y = oneArray(y)
+                oneMKL.gbmv!('N', m, kl, ku, alpha, d_Ab, d_x, beta, d_y)
+                BLAS.gbmv!('N', m, kl, ku, alpha, Ab, x, beta, y)
+                h_y = Array(d_y)
+                @test y ≈ h_y
+
+                # Test: y = alpha * transpose(A) * x + beta * y
+                x = rand(T, n)
+                d_x = oneArray(x)
+                y = rand(T,m)
+                d_y = oneArray(y)
+                oneMKL.gbmv!('T', m, kl, ku, alpha, d_Ab, d_y, beta, d_x)
+                BLAS.gbmv!('T', m, kl, ku, alpha, Ab, y, beta, x)
+                h_x = Array(d_x)
+                @test x ≈ h_x
+
+                # Test: y = alpha * A'*x + beta * y
+                x = rand(T,n)
+                d_x = oneArray(x)
+                y = rand(T,m)
+                d_y = oneArray(y)
+                oneMKL.gbmv!('C', m, kl, ku, alpha, d_Ab, d_y, beta, d_x)
+                BLAS.gbmv!('C', m, kl, ku, alpha, Ab, y, beta, x)
+                h_x = Array(d_x)
+                @test x ≈ h_x
+
+                # Test: alpha=1 version without y
+                d_y = oneMKL.gbmv('N', m, kl, ku, d_Ab, d_x)
+                y = BLAS.gbmv('N', m, kl, ku, Ab, x)
+                h_y = Array(d_y)
+                @test y ≈ h_y
+            end
+
+            @testset "gbmv" begin
+                # test y = alpha*A*x
+                x = rand(T,n)
+                d_x = oneArray(x)
+                d_y = oneMKL.gbmv('N', m, kl, ku, alpha, d_Ab, d_x)
+                y = zeros(T,m)
+                y = BLAS.gbmv('N',m,kl,ku,alpha,Ab,x)
+                h_y = Array(d_y)
+                @test y ≈ h_y
+            end
+
+            A = rand(T,m,m)
+            A = A + A'
+            nbands = 3
+            @test m >= 1+nbands
+            A = bandex(A,nbands,nbands)
+            # convert to 'upper' banded storage format
+            AB = band(A,0,nbands)
+            # construct x
+            x = rand(T,m)
+            d_AB = oneArray(AB)
+            d_x = oneArray(x)
+            if T <:Union{ComplexF32,ComplexF64}
+                @testset "hbmv!" begin
+                    y = rand(T,m)
+                    d_y = oneArray(y)
+                    # hbmv!
+                    oneMKL.hbmv!('U',nbands,alpha,d_AB,d_x,beta,d_y)
+                    y = alpha*(A*x) + beta*y
+                    # compare
+                    h_y = Array(d_y)
+                    @test y ≈ h_y
+                end
+                @testset "hbmv" begin
+                    d_y = oneMKL.hbmv('U',nbands,d_AB,d_x)
+                    y = A*x
+                    # compare
+                    h_y = Array(d_y)
+                    @test y ≈ h_y
+                end
+            else
+                @testset "sbmv!" begin
+                    y = rand(T,m)
+                    d_y = oneArray(y)
+                    # sbmv!
+                    oneMKL.sbmv!('U',nbands,alpha,d_AB,d_x,beta,d_y)
+                    y = alpha*(A*x) + beta*y
+                    # compare
+                    h_y = Array(d_y)
+                    @test y ≈ h_y
+                end
+                @testset "sbmv" begin
+                    d_y = oneMKL.sbmv('U',nbands,d_AB,d_x)
+                    y = A*x
+                    # compare
+                    h_y = Array(d_y)
+                    @test y ≈ h_y
+                end
+            end
+            # generate triangular matrix
+            A = rand(T,m,m)
+            # restrict to 3 bands
+            nbands = 3
+            @test m >= 1+nbands
+            A = bandex(A,0,nbands)
+            # convert to 'upper' banded storage format
+            AB = band(A,0,nbands)
+            d_AB = oneArray(AB)
+            @testset "tbmv!" begin
+                y = rand(T, m)
+                # move to host
+                d_y = oneArray(y)
+                # tbmv!
+                oneMKL.tbmv!('U','N','N',nbands,d_AB,d_y)
+                y = A*y
+                # compare
+                h_y = Array(d_y)
+                @test y ≈ h_y
+            end
+            @testset "tbmv" begin
+                # tbmv
+                d_y = oneMKL.tbmv('U','N','N',nbands,d_AB,d_x)
+                y = A*x
+                # compare
+                h_y = Array(d_y)
+                @test y ≈ h_y
+            end
+            
+        end
+
+        @testset "ger!" begin
+            A = rand(T,m,m)
+            x = rand(T,m)
+            y = rand(T,m)
+            dA = oneArray(A)
+            dx = oneArray(x)
+            dy = oneArray(y)
+            # perform rank one update
+            dB = copy(dA)
+            oneMKL.ger!(alpha,dx,dy,dB)
+            B = (alpha*x)*y' + A
+            # move to host and compare
+            hB = Array(dB)
+            @test B ≈ hB
+        end
+
+        @testset "Triangular" begin
+            @testset "trmv!" begin
+                sA = rand(T,m,m)
+                sA = sA + transpose(sA)
+                A = triu(sA)
+                dA = oneArray(A)
+                x = rand(T, m)
+                dx = oneArray(x)
+                d_y = copy(dx)
+                # execute trmv!
+                oneMKL.trmv!('U','N','N',dA,d_y)
+                y = A*x
+                # compare
+                h_y = Array(d_y)
+                @test y ≈ h_y
+            end
+
+            @testset "trmv" begin
+                sA = rand(T,m,m)
+                sA = sA + transpose(sA)
+                A = triu(sA)
+                dA = oneArray(A) 
+                x = rand(T, m)
+                dx = oneArray(x)
+                d_y = copy(dx)
+                d_y = oneMKL.trmv('U','N','N',dA,dx)
+                y = A*x
+                # compare
+                h_y = Array(d_y)
+                @test y ≈ h_y
+            end
+
+            @testset "trsv!" begin
+                sA = rand(T,m,m)
+                sA = sA + transpose(sA)
+                A = triu(sA)
+                dA = oneArray(A) 
+                x = rand(T, m)
+                dx = oneArray(x)
+                d_y = copy(dx)
+                # execute trsv!
+                oneMKL.trsv!('U','N','N',dA,d_y)
+                y = A\x
+                # compare
+                h_y = Array(d_y)
+                @test y ≈ h_y
+                #@test_throws DimensionMismatch CUBLAS.trsv!('U','N','N',dA,CUDA.rand(elty,m+1))
+            end
+
+            @testset "trsv" begin
+                sA = rand(T,m,m)
+                sA = sA + transpose(sA)
+                A = triu(sA)
+                dA = oneArray(A) 
+                x = rand(T, m)
+                dx = oneArray(x)
+                d_y = oneMKL.trsv('U','N','N',dA,dx)
+                y = A\x
+                # compare
+                h_y = Array(d_y)
+                @test y ≈ h_y
+            end
+
+            @testset "trsv (adjoint)" begin
+                sA = rand(T,m,m)
+                sA = sA + transpose(sA)
+                A = triu(sA)
+                dA = oneArray(A) 
+                x = rand(T, m)
+                dx = oneArray(x)
+                d_y = oneMKL.trsv('U','C','N',dA,dx)
+                y = adjoint(A)\x
+                # compare
+                h_y = Array(d_y)
+                @test y ≈ h_y
+            end
+
+            @testset "trsv (transpose)" begin
+                sA = rand(T,m,m)
+                sA = sA + transpose(sA)
+                A = triu(sA)
+                dA = oneArray(A) 
+                x = rand(T, m)
+                dx = oneArray(x)
+                d_y = oneMKL.trsv('U','T','N',dA,dx)
+                y = transpose(A)\x
+                # compare
+                h_y = Array(d_y)
+                @test y ≈ h_y
+            end
+        end
+    end
+
+    @testset for T in intersect(eltypes, [ComplexF32, ComplexF64])
+        alpha = rand(T)
+        beta = rand(T)
+        @testset "hemv!" begin
+            A = rand(T,m,n)
+            dA = oneArray(A)
+            sA = rand(T,m,m)
+            sA = sA + transpose(sA)
+            dsA = oneArray(sA)
+            hA = rand(T,m,m)
+            hA = hA + hA'
+            dhA = oneArray(hA)
+            x = rand(T,m)
+            dx = oneArray(x)
+            y = rand(T,m)
+            dy = oneArray(y)
+
+            # execute on host
+            BLAS.hemv!('U',alpha,hA,x,beta,y)
+            # execute on device
+            oneMKL.hemv!('U',alpha,dhA,dx,beta,dy)
+
+            # compare results
+            hy = Array(dy)
+            @test y ≈ hy
+        end
+
+        @testset "hemv" begin
+            A = rand(T,m,n)
+            dA = oneArray(A)
+            sA = rand(T,m,m)
+            sA = sA + transpose(sA)
+            dsA = oneArray(sA)
+            hA = rand(T,m,m)
+            hA = hA + hA'
+            dhA = oneArray(hA)
+            x = rand(T,m)
+            dx = oneArray(x)
+            y = rand(T,m)
+            dy = oneArray(y)
+
+            y = BLAS.hemv('U',hA,x)
+            # execute on device
+            dy = oneMKL.hemv('U',dhA,dx)
+            # compare results
+            hy = Array(dy)
+            @test y ≈ hy
+        end
+
+        @testset "her!" begin
+            A = rand(T,m,n)
+            dA = oneArray(A)
+            sA = rand(T,m,m)
+            sA = sA + transpose(sA)
+            dsA = oneArray(sA)
+            hA = rand(T,m,m)
+            hA = hA + hA'
+            dhA = oneArray(hA)
+            x = rand(T,m)
+            dx = oneArray(x)
+            dB = copy(dhA)
+            # perform rank one update
+            oneMKL.her!('U',real(alpha),dx,dB)
+            B = (real(alpha)*x)*x' + hA
+            # move to host and compare upper triangles
+            hB = Array(dB)
+            B = triu(B)
+            hB = triu(hB)
+            @test B ≈ hB
+        end
+
+        @testset "her2!" begin
+            A = rand(T,m,n)
+            dA = oneArray(A)
+            sA = rand(T,m,m)
+            sA = sA + transpose(sA)
+            dsA = oneArray(sA)
+            hA = rand(T,m,m)
+            hA = hA + hA'
+            dhA = oneArray(hA)
+            x = rand(T,m)
+            dx = oneArray(x)
+            y = rand(T,m)
+            dy = oneArray(y)
+            dB = copy(dhA)
+            oneMKL.her2!('U',real(alpha),dx,dy,dB)
+            B = (real(alpha)*x)*y' + y*(real(alpha)*x)' + hA
+            # move to host and compare upper triangles
+            hB = Array(dB)
+            B = triu(B)
+            hB = triu(hB)
+            @test B ≈ hB
+        end
+    end
+
+    @testset "symmetric" begin
+        @testset for T in intersect(eltypes, [Float32, Float64])
+            alpha = rand(T)
+            beta = rand(T)
+            A = rand(T,m,m)
+            A = A + A'
+            nbands = 3
+            @test m >= 1+nbands
+            A = bandex(A,nbands,nbands)
+            # convert to 'upper' banded storage format
+            AB = band(A,0,nbands)
+            # construct x
+            x = rand(T,m)
+            d_AB = oneArray(AB)
+            d_x = oneArray(x)
+            @testset "symv tests" begin
+                x = rand(T,m)
+                sA = rand(T, m, m)
+                sA = sA + transpose(sA)
+                dsA = oneArray(sA)
+                dx = oneArray(x)
+                @testset "symv!" begin
+                    # generate vectors
+                    y = rand(T,m)
+                    # copy to device
+                    dy = oneArray(y)
+                    # execute on host
+                    BLAS.symv!('U',alpha,sA,x,beta,y)
+                    # execute on device
+                    oneMKL.symv!('U',alpha,dsA,dx,beta,dy)
+                    # compare results
+                    hy = Array(dy)
+                    @test y ≈ hy
+                end
+    
+                @testset "symv" begin
+                    y = BLAS.symv('U',sA,x)
+                    # execute on device
+                    dy = oneMKL.symv('U',dsA,dx)
+                    # compare results
+                    hy = Array(dy)
+                    @test y ≈ hy
+                end
+            end
+    
+            @testset "syr!" begin
+                x = rand(T,m)
+                sA = rand(T, m, m)
+                sA = sA + transpose(sA)
+                dsA = oneArray(sA)
+                dx = oneArray(x)
+                dB = copy(dsA)
+                oneMKL.syr!('U',alpha,dx,dB)
+                B = (alpha*x)*transpose(x) + sA
+                # move to host and compare upper triangles
+                hB = Array(dB)
+                B = triu(B)
+                hB = triu(hB)
+                @test B ≈ hB
+            end
         end
     end
 end

--- a/test/onemkl.jl
+++ b/test/onemkl.jl
@@ -62,8 +62,18 @@ m = 20
             @test Array(dy) == x
         end
 
+        @testset "dot" begin
+            @test testf(dot, rand(T,m), rand(T,m))
+            if T == ComplexF32 || T == ComplexF64
+                @test testf(oneMKL.dotu, m, 
+                            oneArray(rand(T,m)),
+                            oneArray(rand(T,m)))
+            end
+        end
+
         @testset "asum" begin
             @test testf(BLAS.asum, rand(T,m))
+
         end
     end
 end


### PR DESCRIPTION
Following is the list of primitives supported in this PR.

**Level - 2:**
1. General: gbmv, gemv, ger
2. symmetric: sbmv, symv, syr
3. triangular: tbmv, trmv, trsv
4. Hermitian: hemv, hbmv, her, her2

**Level - 2:**
1. dot/dotc/dotu