### PR TITLE
Support level 3 primitives

### DIFF
--- a/deps/src/onemkl.cpp
+++ b/deps/src/onemkl.cpp
@@ -350,6 +350,28 @@ extern "C" void onemklZhemm(syclQueue_t device_queue, onemklSide left_right,
     __FORCE_MKL_FLUSH__(status);
 }
 
+extern "C" void onemklCherk(syclQueue_t device_queue, onemklUplo upper_lower,
+                            onemklTranspose trans, int64_t n, int64_t k, float alpha,
+                            const float _Complex *a, int64_t lda, float beta,
+                            float _Complex *c, int64_t ldc) {
+    auto status = oneapi::mkl::blas::column_major::herk(device_queue->val, convert(upper_lower),
+                                          convert(trans), n, k, alpha,
+                                          reinterpret_cast<const std::complex<float> *>(a),
+                                          lda, beta, reinterpret_cast<std::complex<float> *>(c), ldc);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklZherk(syclQueue_t device_queue, onemklUplo upper_lower,
+                            onemklTranspose trans, int64_t n, int64_t k, double alpha,
+                            const double _Complex *a, int64_t lda, double beta,
+                            double _Complex *c, int64_t ldc) {
+    auto status = oneapi::mkl::blas::column_major::herk(device_queue->val, convert(upper_lower),
+                                          convert(trans), n, k, alpha,
+                                          reinterpret_cast<const std::complex<double> *>(a),
+                                          lda, beta, reinterpret_cast<std::complex<double> *>(c), ldc);
+    __FORCE_MKL_FLUSH__(status);
+}
+
 extern "C" void onemklSgbmv(syclQueue_t device_queue, onemklTranspose trans,
                             int64_t m, int64_t n, int64_t kl, int64_t ku, 
                             float alpha, const float *a, int64_t lda,

--- a/deps/src/onemkl.cpp
+++ b/deps/src/onemkl.cpp
@@ -56,9 +56,10 @@ extern "C" int onemklHgemm(syclQueue_t device_queue, onemklTranspose transA,
                            int64_t k, sycl::half alpha, const sycl::half *A, int64_t lda,
                            const sycl::half *B, int64_t ldb, sycl::half beta, sycl::half *C,
                            int64_t ldc) {
-    oneapi::mkl::blas::column_major::gemm(device_queue->val, convert(transA),
+    auto status = oneapi::mkl::blas::column_major::gemm(device_queue->val, convert(transA),
                                           convert(transB), m, n, k, alpha, A,
                                           lda, B, ldb, beta, C, ldc);
+    __FORCE_MKL_FLUSH__(status);
     return 0;
 }
 
@@ -67,9 +68,10 @@ extern "C" int onemklSgemm(syclQueue_t device_queue, onemklTranspose transA,
                            int64_t k, float alpha, const float *A, int64_t lda,
                            const float *B, int64_t ldb, float beta, float *C,
                            int64_t ldc) {
-    oneapi::mkl::blas::column_major::gemm(device_queue->val, convert(transA),
+    auto status = oneapi::mkl::blas::column_major::gemm(device_queue->val, convert(transA),
                                           convert(transB), m, n, k, alpha, A,
                                           lda, B, ldb, beta, C, ldc);
+    __FORCE_MKL_FLUSH__(status);
     return 0;
 }
 
@@ -78,9 +80,10 @@ extern "C" int onemklDgemm(syclQueue_t device_queue, onemklTranspose transA,
                            int64_t k, double alpha, const double *A,
                            int64_t lda, const double *B, int64_t ldb,
                            double beta, double *C, int64_t ldc) {
-    oneapi::mkl::blas::column_major::gemm(device_queue->val, convert(transA),
+    auto status = oneapi::mkl::blas::column_major::gemm(device_queue->val, convert(transA),
                                           convert(transB), m, n, k, alpha, A,
                                           lda, B, ldb, beta, C, ldc);
+    __FORCE_MKL_FLUSH__(status);
     return 0;
 }
 
@@ -91,11 +94,12 @@ extern "C" int onemklCgemm(syclQueue_t device_queue, onemklTranspose transA,
                            const float _Complex *B, int64_t ldb,
                            float _Complex beta, float _Complex *C,
                            int64_t ldc) {
-    oneapi::mkl::blas::column_major::gemm(
+    auto status = oneapi::mkl::blas::column_major::gemm(
         device_queue->val, convert(transA), convert(transB), m, n, k, alpha,
         reinterpret_cast<const std::complex<float> *>(A), lda,
         reinterpret_cast<const std::complex<float> *>(B), ldb, beta,
         reinterpret_cast<std::complex<float> *>(C), ldc);
+    __FORCE_MKL_FLUSH__(status);
     return 0;
 }
 
@@ -106,11 +110,12 @@ extern "C" int onemklZgemm(syclQueue_t device_queue, onemklTranspose transA,
                            const double _Complex *B, int64_t ldb,
                            double _Complex beta, double _Complex *C,
                            int64_t ldc) {
-    oneapi::mkl::blas::column_major::gemm(
+    auto status = oneapi::mkl::blas::column_major::gemm(
         device_queue->val, convert(transA), convert(transB), m, n, k, alpha,
         reinterpret_cast<const std::complex<double> *>(A), lda,
         reinterpret_cast<const std::complex<double> *>(B), ldb, beta,
         reinterpret_cast<std::complex<double> *>(C), ldc);
+    __FORCE_MKL_FLUSH__(status);
     return 0;
 }
 
@@ -118,18 +123,20 @@ extern "C" void onemklSsymm(syclQueue_t device_queue, onemklSide left_right,
                             onemklUplo upper_lower, int64_t m, int64_t n,
                             float alpha, const float *a, int64_t lda, const float *b,
                             int64_t ldb, float beta, float *c, int64_t ldc) {
-    oneapi::mkl::blas::column_major::symm(device_queue->val, convert(left_right),
-                                          convert(upper_lower), m, n, alpha, a, lda, b,
-                                          ldb, beta, c, ldc);
+    auto status = oneapi::mkl::blas::column_major::symm(device_queue->val,
+                                        convert(left_right), convert(upper_lower),
+                                        m, n, alpha, a, lda, b, ldb, beta, c, ldc);
+    __FORCE_MKL_FLUSH__(status);
 }
 
 extern "C" void onemklDsymm(syclQueue_t device_queue, onemklSide left_right,
                             onemklUplo upper_lower, int64_t m, int64_t n,
                             double alpha, const double *a, int64_t lda, const double *b,
                             int64_t ldb, double beta, double *c, int64_t ldc) {
-    oneapi::mkl::blas::column_major::symm(device_queue->val, convert(left_right),
+    auto status = oneapi::mkl::blas::column_major::symm(device_queue->val, convert(left_right),
                                           convert(upper_lower), m, n, alpha, a, lda, b,
                                           ldb, beta, c, ldc);
+    __FORCE_MKL_FLUSH__(status);
 }
 
 extern "C" void onemklCsymm(syclQueue_t device_queue, onemklSide left_right,
@@ -137,12 +144,13 @@ extern "C" void onemklCsymm(syclQueue_t device_queue, onemklSide left_right,
                             float _Complex alpha, const float _Complex *a, int64_t lda,
                             const float _Complex *b, int64_t ldb, float _Complex beta,
                             float _Complex *c, int64_t ldc) {
-    oneapi::mkl::blas::column_major::symm(device_queue->val, convert(left_right),
+    auto status = oneapi::mkl::blas::column_major::symm(device_queue->val, convert(left_right),
                                           convert(upper_lower), m, n,
                                           static_cast<std::complex<float> >(alpha),
                                           reinterpret_cast<const std::complex<float> *>(a),
                                           lda, reinterpret_cast<const std::complex<float> *>(b),
                                           ldb, beta, reinterpret_cast<std::complex<float> *>(c), ldc);
+    __FORCE_MKL_FLUSH__(status);
 }
 
 extern "C" void onemklZsymm(syclQueue_t device_queue, onemklSide left_right,
@@ -150,87 +158,98 @@ extern "C" void onemklZsymm(syclQueue_t device_queue, onemklSide left_right,
                             double _Complex alpha, const double _Complex *a, int64_t lda,
                             const double _Complex *b, int64_t ldb, double _Complex beta,
                             double _Complex *c, int64_t ldc) {
-    oneapi::mkl::blas::column_major::symm(device_queue->val, convert(left_right),
+    auto status = oneapi::mkl::blas::column_major::symm(device_queue->val, convert(left_right),
                                           convert(upper_lower), m, n,
                                           static_cast<std::complex<double> >(alpha),
                                           reinterpret_cast<const std::complex<double> *>(a), lda,
                                           reinterpret_cast<const std::complex<double> *>(b), ldb,
                                           static_cast<std::complex<double> >(beta),
                                           reinterpret_cast<std::complex<double> *>(c), ldc);
+    __FORCE_MKL_FLUSH__(status);
 }
 
 extern "C" void onemklSsyrk(syclQueue_t device_queue, onemklUplo upper_lower,
                             onemklTranspose trans, int64_t n, int64_t k, float alpha,
                             const float *a, int64_t lda, float beta, float *c, int64_t ldc) {
-    oneapi::mkl::blas::column_major::syrk(device_queue->val, convert(upper_lower), convert(trans),
-                                          n, k, alpha, a, lda, beta, c, ldc);
+    auto status = oneapi::mkl::blas::column_major::syrk(device_queue->val, convert(upper_lower),
+                                        convert(trans), n, k, alpha, a, lda, beta, c, ldc);
+    __FORCE_MKL_FLUSH__(status);
 }
 
 extern "C" void onemklDsyrk(syclQueue_t device_queue, onemklUplo upper_lower,
                             onemklTranspose trans, int64_t n, int64_t k, double alpha,
                             const double *a, int64_t lda, double beta, double *c, int64_t ldc) {
-    oneapi::mkl::blas::column_major::syrk(device_queue->val, convert(upper_lower), convert(trans),
-                                          n, k, alpha, a, lda, beta, c, ldc);
+    auto status = oneapi::mkl::blas::column_major::syrk(device_queue->val, convert(upper_lower),
+                                        convert(trans), n, k, alpha, a, lda, beta, c, ldc);
+    __FORCE_MKL_FLUSH__(status);
 }
 
 extern "C" void onemklCsyrk(syclQueue_t device_queue, onemklUplo upper_lower,
-                            onemklTranspose trans, int64_t n, int64_t k, float _Complex alpha,
-                            const float _Complex *a, int64_t lda, float _Complex beta, float _Complex *c,
-                            int64_t ldc) {
-    oneapi::mkl::blas::column_major::syrk(device_queue->val, convert(upper_lower), convert(trans),
-                                          n, k, static_cast<std::complex<float> >(alpha),
-                                          reinterpret_cast<const std::complex<float> *>(a), lda,
-                                          static_cast<std::complex<float> >(beta),
-                                          reinterpret_cast<std::complex<float> *>(c), ldc);
+                            onemklTranspose trans, int64_t n, int64_t k,
+                            float _Complex alpha, const float _Complex *a,
+                            int64_t lda, float _Complex beta,
+                            float _Complex *c, int64_t ldc) {
+    auto status = oneapi::mkl::blas::column_major::syrk(device_queue->val, convert(upper_lower),
+                                        convert(trans), n, k, static_cast<std::complex<float> >(alpha),
+                                        reinterpret_cast<const std::complex<float> *>(a), lda,
+                                        static_cast<std::complex<float> >(beta),
+                                        reinterpret_cast<std::complex<float> *>(c), ldc);
+    __FORCE_MKL_FLUSH__(status);
 }
 
 extern "C" void onemklZsyrk(syclQueue_t device_queue, onemklUplo upper_lower,
-                            onemklTranspose trans, int64_t n, int64_t k, double _Complex alpha,
-                            const double _Complex *a, int64_t lda, double _Complex beta, double _Complex *c,
-                            int64_t ldc) {
-    oneapi::mkl::blas::column_major::syrk(device_queue->val, convert(upper_lower), convert(trans),
-                                          n, k, static_cast<std::complex<float> >(alpha),
-                                          reinterpret_cast<const std::complex<double> *>(a), lda,
-                                          static_cast<std::complex<double> >(beta),
-                                          reinterpret_cast<std::complex<double> *>(c), ldc);
+                            onemklTranspose trans, int64_t n, int64_t k,
+                            double _Complex alpha, const double _Complex *a,
+                            int64_t lda, double _Complex beta,
+                            double _Complex *c, int64_t ldc) {
+    auto status = oneapi::mkl::blas::column_major::syrk(device_queue->val, convert(upper_lower),
+                                        convert(trans), n, k, static_cast<std::complex<float> >(alpha),
+                                        reinterpret_cast<const std::complex<double> *>(a), lda,
+                                        static_cast<std::complex<double> >(beta),
+                                        reinterpret_cast<std::complex<double> *>(c), ldc);
+    __FORCE_MKL_FLUSH__(status);
 }
 
 extern "C" void onemklSsyr2k(syclQueue_t device_queue, onemklUplo upper_lower, onemklTranspose trans,
                              int64_t n, int64_t k, float alpha, const float *a, int64_t lda,
                              const float *b, int64_t ldb, float beta, float *c, int64_t ldc) {
-    oneapi::mkl::blas::column_major::syr2k(device_queue->val, convert(upper_lower), convert(trans),
-                                           n, k, alpha, a, lda, b, ldb, beta, c, ldc);
+    auto status = oneapi::mkl::blas::column_major::syr2k(device_queue->val, convert(upper_lower),
+                                        convert(trans), n, k, alpha, a, lda, b, ldb, beta, c, ldc);
+    __FORCE_MKL_FLUSH__(status);
 }
 
 extern "C" void onemklDsyr2k(syclQueue_t device_queue, onemklUplo upper_lower, onemklTranspose trans,
                              int64_t n, int64_t k, double alpha, const double *a, int64_t lda,
                              const double *b, int64_t ldb, double beta, double *c, int64_t ldc) {
-    oneapi::mkl::blas::column_major::syr2k(device_queue->val, convert(upper_lower), convert(trans),
-                                           n, k, alpha, a, lda, b, ldb, beta, c, ldc);
+    auto status = oneapi::mkl::blas::column_major::syr2k(device_queue->val, convert(upper_lower),
+                                        convert(trans), n, k, alpha, a, lda, b, ldb, beta, c, ldc);
+    __FORCE_MKL_FLUSH__(status);
 }
 
 extern "C" void onemklCsyr2k(syclQueue_t device_queue, onemklUplo upper_lower, onemklTranspose trans,
                              int64_t n, int64_t k, float _Complex alpha, const float _Complex *a,
                              int64_t lda, const float _Complex *b, int64_t ldb, float _Complex beta,
                              float _Complex *c, int64_t ldc) {
-    oneapi::mkl::blas::column_major::syr2k(device_queue->val, convert(upper_lower), convert(trans),
-                                           n, k, static_cast<std::complex<float> >(alpha),
-                                           reinterpret_cast<const std::complex<float> *>(a), lda,
-                                           reinterpret_cast<const std::complex<float> *>(b), ldb,
-                                           static_cast<std::complex<float> >(beta),
-                                           reinterpret_cast<std::complex<float> *>(c), ldc);
+    auto status = oneapi::mkl::blas::column_major::syr2k(device_queue->val, convert(upper_lower),
+                                        convert(trans), n, k, static_cast<std::complex<float> >(alpha),
+                                        reinterpret_cast<const std::complex<float> *>(a), lda,
+                                        reinterpret_cast<const std::complex<float> *>(b), ldb,
+                                        static_cast<std::complex<float> >(beta),
+                                        reinterpret_cast<std::complex<float> *>(c), ldc);
+    __FORCE_MKL_FLUSH__(status);
 }
 
 extern "C" void onemklZsyr2k(syclQueue_t device_queue, onemklUplo upper_lower, onemklTranspose trans,
                              int64_t n, int64_t k, double _Complex alpha, const double _Complex *a,
                              int64_t lda, const double _Complex *b, int64_t ldb, double _Complex beta,
                              double _Complex *c, int64_t ldc) {
-    oneapi::mkl::blas::column_major::syr2k(device_queue->val, convert(upper_lower), convert(trans),
-                                           n, k, static_cast<std::complex<double> >(alpha),
-                                           reinterpret_cast<const std::complex<double> *>(a), lda,
-                                           reinterpret_cast<const std::complex<double> *>(b), ldb,
-                                           static_cast<std::complex<double> >(beta),
-                                           reinterpret_cast<std::complex<double> *>(c), ldc);
+    auto status = oneapi::mkl::blas::column_major::syr2k(device_queue->val, convert(upper_lower),
+                                        convert(trans), n, k, static_cast<std::complex<double> >(alpha),
+                                        reinterpret_cast<const std::complex<double> *>(a), lda,
+                                        reinterpret_cast<const std::complex<double> *>(b), ldb,
+                                        static_cast<std::complex<double> >(beta),
+                                        reinterpret_cast<std::complex<double> *>(c), ldc);
+    __FORCE_MKL_FLUSH__(status);
 }
 
 extern "C" void onemklStrmm(syclQueue_t device_queue, onemklSide left_right,

--- a/deps/src/onemkl.cpp
+++ b/deps/src/onemkl.cpp
@@ -42,6 +42,15 @@ oneapi::mkl::diag convert(onemklDiag val) {
     }
 }
 
+oneapi::mkl::side convert(onemklSide val) {
+    switch (val) {
+    case ONEMKL_SIDE_LEFT:
+        return oneapi::mkl::side::left;
+    case ONEMKL_SIDE_RIGHT:
+        return oneapi::mkl::side::right;
+    }
+}
+
 extern "C" int onemklHgemm(syclQueue_t device_queue, onemklTranspose transA,
                            onemklTranspose transB, int64_t m, int64_t n,
                            int64_t k, sycl::half alpha, const sycl::half *A, int64_t lda,
@@ -103,6 +112,51 @@ extern "C" int onemklZgemm(syclQueue_t device_queue, onemklTranspose transA,
         reinterpret_cast<const std::complex<double> *>(B), ldb, beta,
         reinterpret_cast<std::complex<double> *>(C), ldc);
     return 0;
+}
+
+extern "C" void onemklSsymm(syclQueue_t device_queue, onemklSide left_right,
+                            onemklUplo upper_lower, int64_t m, int64_t n,
+                            float alpha, const float *a, int64_t lda, const float *b,
+                            int64_t ldb, float beta, float *c, int64_t ldc) {
+    oneapi::mkl::blas::column_major::symm(device_queue->val, convert(left_right),
+                                          convert(upper_lower), m, n, alpha, a, lda, b,
+                                          ldb, beta, c, ldc);
+}
+
+extern "C" void onemklDsymm(syclQueue_t device_queue, onemklSide left_right,
+                            onemklUplo upper_lower, int64_t m, int64_t n,
+                            double alpha, const double *a, int64_t lda, const double *b,
+                            int64_t ldb, double beta, double *c, int64_t ldc) {
+    oneapi::mkl::blas::column_major::symm(device_queue->val, convert(left_right),
+                                          convert(upper_lower), m, n, alpha, a, lda, b,
+                                          ldb, beta, c, ldc);
+}
+
+extern "C" void onemklCsymm(syclQueue_t device_queue, onemklSide left_right,
+                            onemklUplo upper_lower, int64_t m, int64_t n,
+                            float _Complex alpha, const float _Complex *a, int64_t lda,
+                            const float _Complex *b, int64_t ldb, float _Complex beta,
+                            float _Complex *c, int64_t ldc) {
+    oneapi::mkl::blas::column_major::symm(device_queue->val, convert(left_right),
+                                          convert(upper_lower), m, n,
+                                          static_cast<std::complex<float> >(alpha),
+                                          reinterpret_cast<const std::complex<float> *>(a),
+                                          lda, reinterpret_cast<const std::complex<float> *>(b),
+                                          ldb, beta, reinterpret_cast<std::complex<float> *>(c), ldc);
+}
+
+extern "C" void onemklZsymm(syclQueue_t device_queue, onemklSide left_right,
+                            onemklUplo upper_lower, int64_t m, int64_t n,
+                            double _Complex alpha, const double _Complex *a, int64_t lda,
+                            const double _Complex *b, int64_t ldb, double _Complex beta,
+                            double _Complex *c, int64_t ldc) {
+    oneapi::mkl::blas::column_major::symm(device_queue->val, convert(left_right),
+                                          convert(upper_lower), m, n,
+                                          static_cast<std::complex<double> >(alpha),
+                                          reinterpret_cast<const std::complex<double> *>(a), lda,
+                                          reinterpret_cast<const std::complex<double> *>(b), ldb,
+                                          static_cast<std::complex<double> >(beta),
+                                          reinterpret_cast<std::complex<double> *>(c), ldc);
 }
 
 extern "C" void onemklSgbmv(syclQueue_t device_queue, onemklTranspose trans,

--- a/deps/src/onemkl.cpp
+++ b/deps/src/onemkl.cpp
@@ -233,6 +233,93 @@ extern "C" void onemklZsyr2k(syclQueue_t device_queue, onemklUplo upper_lower, o
                                            reinterpret_cast<std::complex<double> *>(c), ldc);
 }
 
+extern "C" void onemklStrmm(syclQueue_t device_queue, onemklSide left_right,
+                            onemklUplo uppler_lower, onemklTranspose trans,
+                            onemklDiag diag, int64_t m, int64_t n, float alpha,
+                            const float *a, int64_t lda, float *b, int64_t ldb) {
+    auto status = oneapi::mkl::blas::column_major::trmm(device_queue->val, convert(left_right),
+                                          convert(uppler_lower), convert(trans),
+                                          convert(diag), m, n, alpha, a, lda, b, ldb);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklDtrmm(syclQueue_t device_queue, onemklSide left_right,
+                            onemklUplo uppler_lower, onemklTranspose trans,
+                            onemklDiag diag, int64_t m, int64_t n, double alpha,
+                            const double *a, int64_t lda, double *b, int64_t ldb) {
+    auto status = oneapi::mkl::blas::column_major::trmm(device_queue->val, convert(left_right),
+                                          convert(uppler_lower), convert(trans),
+                                          convert(diag), m, n, alpha, a, lda, b, ldb);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklCtrmm(syclQueue_t device_queue, onemklSide left_right,
+                            onemklUplo uppler_lower, onemklTranspose trans,
+                            onemklDiag diag, int64_t m, int64_t n, float _Complex alpha,
+                            const float _Complex *a, int64_t lda, float _Complex *b,
+                            int64_t ldb) {
+    auto status = oneapi::mkl::blas::column_major::trmm(device_queue->val, convert(left_right),
+                                          convert(uppler_lower), convert(trans),
+                                          convert(diag), m, n, static_cast<std::complex<float> >(alpha),
+                                          reinterpret_cast<const std::complex<float> *>(a), lda,
+                                          reinterpret_cast<std::complex<float> *>(b), ldb);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklZtrmm(syclQueue_t device_queue, onemklSide left_right,
+                            onemklUplo uppler_lower, onemklTranspose trans,
+                            onemklDiag diag, int64_t m, int64_t n, double _Complex alpha,
+                            const double _Complex *a, int64_t lda, double _Complex *b, int64_t ldb) {
+    auto status = oneapi::mkl::blas::column_major::trmm(device_queue->val, convert(left_right),
+                                          convert(uppler_lower), convert(trans),
+                                          convert(diag), m, n, static_cast<std::complex<double> >(alpha),
+                                          reinterpret_cast<const std::complex<double> *>(a), lda,
+                                          reinterpret_cast<std::complex<double> *>(b), ldb);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklStrsm(syclQueue_t device_queue, onemklSide left_right, onemklUplo upper_lower,
+                            onemklTranspose transa, onemklDiag unit_diag, int64_t m, int64_t n,
+                            float alpha, const float *a, int64_t lda, float *b, int64_t ldb) {
+    auto status = oneapi::mkl::blas::column_major::trsm(device_queue->val, convert(left_right),
+                                        convert(upper_lower), convert(transa), convert(unit_diag),
+                                        m, n, alpha, a, lda, b, ldb);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklDtrsm(syclQueue_t device_queue, onemklSide left_right, onemklUplo upper_lower,
+                            onemklTranspose transa, onemklDiag unit_diag, int64_t m, int64_t n,
+                            double alpha, const double *a, int64_t lda, double *b, int64_t ldb) {
+    auto status = oneapi::mkl::blas::column_major::trsm(device_queue->val, convert(left_right),
+                                        convert(upper_lower), convert(transa), convert(unit_diag),
+                                        m, n, alpha, a, lda, b, ldb);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklCtrsm(syclQueue_t device_queue, onemklSide left_right, onemklUplo upper_lower,
+                            onemklTranspose transa, onemklDiag unit_diag, int64_t m, int64_t n,
+                            float _Complex alpha, const float _Complex *a, int64_t lda, float _Complex *b,
+                            int64_t ldb) {
+    auto status = oneapi::mkl::blas::column_major::trsm(device_queue->val, convert(left_right),
+                                        convert(upper_lower), convert(transa), convert(unit_diag),
+                                        m, n, static_cast<std::complex<float> >(alpha),
+                                        reinterpret_cast<const std::complex<float> *>(a), lda,
+                                        reinterpret_cast<std::complex<float> *>(b), ldb);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklZtrsm(syclQueue_t device_queue, onemklSide left_right, onemklUplo upper_lower,
+                            onemklTranspose transa, onemklDiag unit_diag, int64_t m, int64_t n,
+                            double _Complex alpha, const double _Complex *a, int64_t lda,
+                            double _Complex *b, int64_t ldb) {
+    auto status = oneapi::mkl::blas::column_major::trsm(device_queue->val, convert(left_right),
+                                        convert(upper_lower), convert(transa), convert(unit_diag),
+                                        m, n, static_cast<std::complex<double> >(alpha),
+                                        reinterpret_cast<const std::complex<double> *>(a), lda,
+                                        reinterpret_cast<std::complex<double> *>(b), ldb);
+    __FORCE_MKL_FLUSH__(status);
+}
+
 extern "C" void onemklSgbmv(syclQueue_t device_queue, onemklTranspose trans,
                             int64_t m, int64_t n, int64_t kl, int64_t ku, 
                             float alpha, const float *a, int64_t lda,

--- a/deps/src/onemkl.cpp
+++ b/deps/src/onemkl.cpp
@@ -195,6 +195,44 @@ extern "C" void onemklZsyrk(syclQueue_t device_queue, onemklUplo upper_lower,
                                           reinterpret_cast<std::complex<double> *>(c), ldc);
 }
 
+extern "C" void onemklSsyr2k(syclQueue_t device_queue, onemklUplo upper_lower, onemklTranspose trans,
+                             int64_t n, int64_t k, float alpha, const float *a, int64_t lda,
+                             const float *b, int64_t ldb, float beta, float *c, int64_t ldc) {
+    oneapi::mkl::blas::column_major::syr2k(device_queue->val, convert(upper_lower), convert(trans),
+                                           n, k, alpha, a, lda, b, ldb, beta, c, ldc);
+}
+
+extern "C" void onemklDsyr2k(syclQueue_t device_queue, onemklUplo upper_lower, onemklTranspose trans,
+                             int64_t n, int64_t k, double alpha, const double *a, int64_t lda,
+                             const double *b, int64_t ldb, double beta, double *c, int64_t ldc) {
+    oneapi::mkl::blas::column_major::syr2k(device_queue->val, convert(upper_lower), convert(trans),
+                                           n, k, alpha, a, lda, b, ldb, beta, c, ldc);
+}
+
+extern "C" void onemklCsyr2k(syclQueue_t device_queue, onemklUplo upper_lower, onemklTranspose trans,
+                             int64_t n, int64_t k, float _Complex alpha, const float _Complex *a,
+                             int64_t lda, const float _Complex *b, int64_t ldb, float _Complex beta,
+                             float _Complex *c, int64_t ldc) {
+    oneapi::mkl::blas::column_major::syr2k(device_queue->val, convert(upper_lower), convert(trans),
+                                           n, k, static_cast<std::complex<float> >(alpha),
+                                           reinterpret_cast<const std::complex<float> *>(a), lda,
+                                           reinterpret_cast<const std::complex<float> *>(b), ldb,
+                                           static_cast<std::complex<float> >(beta),
+                                           reinterpret_cast<std::complex<float> *>(c), ldc);
+}
+
+extern "C" void onemklZsyr2k(syclQueue_t device_queue, onemklUplo upper_lower, onemklTranspose trans,
+                             int64_t n, int64_t k, double _Complex alpha, const double _Complex *a,
+                             int64_t lda, const double _Complex *b, int64_t ldb, double _Complex beta,
+                             double _Complex *c, int64_t ldc) {
+    oneapi::mkl::blas::column_major::syr2k(device_queue->val, convert(upper_lower), convert(trans),
+                                           n, k, static_cast<std::complex<double> >(alpha),
+                                           reinterpret_cast<const std::complex<double> *>(a), lda,
+                                           reinterpret_cast<const std::complex<double> *>(b), ldb,
+                                           static_cast<std::complex<double> >(beta),
+                                           reinterpret_cast<std::complex<double> *>(c), ldc);
+}
+
 extern "C" void onemklSgbmv(syclQueue_t device_queue, onemklTranspose trans,
                             int64_t m, int64_t n, int64_t kl, int64_t ku, 
                             float alpha, const float *a, int64_t lda,

--- a/deps/src/onemkl.cpp
+++ b/deps/src/onemkl.cpp
@@ -320,6 +320,36 @@ extern "C" void onemklZtrsm(syclQueue_t device_queue, onemklSide left_right, one
     __FORCE_MKL_FLUSH__(status);
 }
 
+extern "C" void onemklChemm(syclQueue_t device_queue, onemklSide left_right,
+                            onemklUplo upper_lower, int64_t m, int64_t n, 
+                            float _Complex alpha, const float _Complex *a,
+                            int64_t lda, const float _Complex *b, int64_t ldb,
+                            float _Complex beta, float _Complex *c, int64_t ldc) {
+    auto status = oneapi::mkl::blas::column_major::hemm(device_queue->val, convert(left_right),
+                                          convert(upper_lower), m, n, 
+                                          static_cast<std::complex<float> >(alpha),
+                                          reinterpret_cast<const std::complex<float> *>(a),
+                                          lda, reinterpret_cast<const std::complex<float> *>(b),
+                                          ldb, static_cast<std::complex<float> >(beta),
+                                          reinterpret_cast<std::complex<float> *>(c), ldc);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklZhemm(syclQueue_t device_queue, onemklSide left_right,
+                            onemklUplo upper_lower, int64_t m, int64_t n, 
+                            double _Complex alpha, const double _Complex *a,
+                            int64_t lda, const double _Complex *b, int64_t ldb,
+                            double _Complex beta, double _Complex *c, int64_t ldc) {
+    auto status = oneapi::mkl::blas::column_major::hemm(device_queue->val, convert(left_right),
+                                          convert(upper_lower), m, n, 
+                                          static_cast<std::complex<double> >(alpha),
+                                          reinterpret_cast<const std::complex<double> *>(a),
+                                          lda, reinterpret_cast<const std::complex<double> *>(b),
+                                          ldb, static_cast<std::complex<double> >(beta),
+                                          reinterpret_cast<std::complex<double> *>(c), ldc);
+    __FORCE_MKL_FLUSH__(status);
+}
+
 extern "C" void onemklSgbmv(syclQueue_t device_queue, onemklTranspose trans,
                             int64_t m, int64_t n, int64_t kl, int64_t ku, 
                             float alpha, const float *a, int64_t lda,

--- a/deps/src/onemkl.cpp
+++ b/deps/src/onemkl.cpp
@@ -159,6 +159,42 @@ extern "C" void onemklZsymm(syclQueue_t device_queue, onemklSide left_right,
                                           reinterpret_cast<std::complex<double> *>(c), ldc);
 }
 
+extern "C" void onemklSsyrk(syclQueue_t device_queue, onemklUplo upper_lower,
+                            onemklTranspose trans, int64_t n, int64_t k, float alpha,
+                            const float *a, int64_t lda, float beta, float *c, int64_t ldc) {
+    oneapi::mkl::blas::column_major::syrk(device_queue->val, convert(upper_lower), convert(trans),
+                                          n, k, alpha, a, lda, beta, c, ldc);
+}
+
+extern "C" void onemklDsyrk(syclQueue_t device_queue, onemklUplo upper_lower,
+                            onemklTranspose trans, int64_t n, int64_t k, double alpha,
+                            const double *a, int64_t lda, double beta, double *c, int64_t ldc) {
+    oneapi::mkl::blas::column_major::syrk(device_queue->val, convert(upper_lower), convert(trans),
+                                          n, k, alpha, a, lda, beta, c, ldc);
+}
+
+extern "C" void onemklCsyrk(syclQueue_t device_queue, onemklUplo upper_lower,
+                            onemklTranspose trans, int64_t n, int64_t k, float _Complex alpha,
+                            const float _Complex *a, int64_t lda, float _Complex beta, float _Complex *c,
+                            int64_t ldc) {
+    oneapi::mkl::blas::column_major::syrk(device_queue->val, convert(upper_lower), convert(trans),
+                                          n, k, static_cast<std::complex<float> >(alpha),
+                                          reinterpret_cast<const std::complex<float> *>(a), lda,
+                                          static_cast<std::complex<float> >(beta),
+                                          reinterpret_cast<std::complex<float> *>(c), ldc);
+}
+
+extern "C" void onemklZsyrk(syclQueue_t device_queue, onemklUplo upper_lower,
+                            onemklTranspose trans, int64_t n, int64_t k, double _Complex alpha,
+                            const double _Complex *a, int64_t lda, double _Complex beta, double _Complex *c,
+                            int64_t ldc) {
+    oneapi::mkl::blas::column_major::syrk(device_queue->val, convert(upper_lower), convert(trans),
+                                          n, k, static_cast<std::complex<float> >(alpha),
+                                          reinterpret_cast<const std::complex<double> *>(a), lda,
+                                          static_cast<std::complex<double> >(beta),
+                                          reinterpret_cast<std::complex<double> *>(c), ldc);
+}
+
 extern "C" void onemklSgbmv(syclQueue_t device_queue, onemklTranspose trans,
                             int64_t m, int64_t n, int64_t kl, int64_t ku, 
                             float alpha, const float *a, int64_t lda,

--- a/deps/src/onemkl.cpp
+++ b/deps/src/onemkl.cpp
@@ -372,6 +372,32 @@ extern "C" void onemklZherk(syclQueue_t device_queue, onemklUplo upper_lower,
     __FORCE_MKL_FLUSH__(status);
 }
 
+extern "C" void onemklCher2k(syclQueue_t device_queue, onemklUplo upper_lower,
+                             onemklTranspose trans, int64_t n, int64_t k,
+                             float _Complex alpha, const float _Complex *a,
+                             int64_t lda, const float _Complex *b, int64_t ldb,
+                             float beta, float _Complex *c, int64_t ldc) {
+    auto status = oneapi::mkl::blas::column_major::her2k(device_queue->val, convert(upper_lower),
+                                           convert(trans), n, k, static_cast<std::complex<float> >(alpha),
+                                           reinterpret_cast<const std::complex<float> *>(a), lda,
+                                           reinterpret_cast<const std::complex<float> *>(b), ldb,
+                                           beta, reinterpret_cast<std::complex<float> *>(c), ldc);
+    __FORCE_MKL_FLUSH__(status);
+}
+
+extern "C" void onemklZher2k(syclQueue_t device_queue, onemklUplo upper_lower,
+                             onemklTranspose trans, int64_t n, int64_t k,
+                             double _Complex alpha, const double _Complex *a,
+                             int64_t lda, const double _Complex *b, int64_t ldb,
+                             double beta, double _Complex *c, int64_t ldc) {
+    auto status = oneapi::mkl::blas::column_major::her2k(device_queue->val, convert(upper_lower),
+                                           convert(trans), n, k, static_cast<std::complex<double> >(alpha),
+                                           reinterpret_cast<const std::complex<double> *>(a), lda,
+                                           reinterpret_cast<const std::complex<double> *>(b), ldb,
+                                           beta, reinterpret_cast<std::complex<double> *>(c), ldc);
+    __FORCE_MKL_FLUSH__(status);
+}
+
 extern "C" void onemklSgbmv(syclQueue_t device_queue, onemklTranspose trans,
                             int64_t m, int64_t n, int64_t kl, int64_t ku, 
                             float alpha, const float *a, int64_t lda,

--- a/deps/src/onemkl.h
+++ b/deps/src/onemkl.h
@@ -73,6 +73,21 @@ void onemklZsymm(syclQueue_t device_queue, onemklSide left_right,
                 const double _Complex *b, int64_t ldb, double _Complex beta,
                 double _Complex *c, int64_t ldc);
 
+void onemklSsyrk(syclQueue_t device_queue, onemklUplo upper_lower,
+                onemklTranspose trans, int64_t n, int64_t k, float alpha,
+                const float *a, int64_t lda, float beta, float *c, int64_t ldc);
+void onemklDsyrk(syclQueue_t device_queue, onemklUplo upper_lower,
+                onemklTranspose trans, int64_t n, int64_t k, double alpha,
+                const double *a, int64_t lda, double beta, double *c, int64_t ldc);
+void onemklCsyrk(syclQueue_t device_queue, onemklUplo upper_lower,
+                onemklTranspose trans, int64_t n, int64_t k, float _Complex alpha,
+                const float _Complex *a, int64_t lda, float _Complex beta, float _Complex *c,
+                int64_t ldc);
+void onemklZsyrk(syclQueue_t device_queue, onemklUplo upper_lower,
+                onemklTranspose trans, int64_t n, int64_t k, double _Complex alpha,
+                const double _Complex *a, int64_t lda, double _Complex beta, double _Complex *c,
+                int64_t ldc);
+
 void onemklSgbmv(syclQueue_t device_queue, onemklTranspose trans, int64_t m,
                 int64_t n, int64_t kl, int64_t ku, float alpha, const float *a,
                 int64_t lda, const float *x, int64_t incx, float beta, float *y,

--- a/deps/src/onemkl.h
+++ b/deps/src/onemkl.h
@@ -156,6 +156,17 @@ void onemklZherk(syclQueue_t device_queue, onemklUplo upper_lower,
                 const double _Complex *a, int64_t lda, double beta,
                 double _Complex *c, int64_t ldc);
 
+void onemklCher2k(syclQueue_t device_queue, onemklUplo upper_lower,
+                             onemklTranspose trans, int64_t n, int64_t k,
+                             float _Complex alpha, const float _Complex *a,
+                             int64_t lda, const float _Complex *b, int64_t ldb,
+                             float beta, float _Complex *c, int64_t ldc);
+void onemklZher2k(syclQueue_t device_queue, onemklUplo upper_lower,
+                             onemklTranspose trans, int64_t n, int64_t k,
+                             double _Complex alpha, const double _Complex *a,
+                             int64_t lda, const double _Complex *b, int64_t ldb,
+                             double beta, double _Complex *c, int64_t ldc);
+
 void onemklSgbmv(syclQueue_t device_queue, onemklTranspose trans, int64_t m,
                 int64_t n, int64_t kl, int64_t ku, float alpha, const float *a,
                 int64_t lda, const float *x, int64_t incx, float beta, float *y,

--- a/deps/src/onemkl.h
+++ b/deps/src/onemkl.h
@@ -136,6 +136,17 @@ void onemklZtrsm(syclQueue_t device_queue, onemklSide left_right, onemklUplo upp
                 double _Complex alpha, const double _Complex *a, int64_t lda, double _Complex *b,
                 int64_t ldb);
 
+void onemklChemm(syclQueue_t device_queue, onemklSide left_right,
+                            onemklUplo upper_lower, int64_t m, int64_t n, 
+                            float _Complex alpha, const float _Complex *a,
+                            int64_t lda, const float _Complex *b, int64_t ldb,
+                            float _Complex beta, float _Complex *c, int64_t ldc);
+void onemklZhemm(syclQueue_t device_queue, onemklSide left_right,
+                            onemklUplo upper_lower, int64_t m, int64_t n, 
+                            double _Complex alpha, const double _Complex *a,
+                            int64_t lda, const double _Complex *b, int64_t ldb,
+                            double _Complex beta, double _Complex *c, int64_t ldc);
+
 void onemklSgbmv(syclQueue_t device_queue, onemklTranspose trans, int64_t m,
                 int64_t n, int64_t kl, int64_t ku, float alpha, const float *a,
                 int64_t lda, const float *x, int64_t incx, float beta, float *y,

--- a/deps/src/onemkl.h
+++ b/deps/src/onemkl.h
@@ -25,6 +25,11 @@ typedef enum {
     ONEMKL_DIAG_UNIT
  } onemklDiag;
 
+typedef enum {
+    ONEMKL_SIDE_LEFT,
+    ONEMKL_SIDE_RIGHT
+} onemklSide;
+
 // XXX: how to expose half in C?
 // int onemklHgemm(syclQueue_t device_queue, onemklTranspose transA,
 //                onemklTranspose transB, int64_t m, int64_t n, int64_t k,
@@ -48,6 +53,25 @@ int onemklZgemm(syclQueue_t device_queue, onemklTranspose transA,
                 double _Complex alpha, const double _Complex *A, int64_t lda,
                 const double _Complex *B, int64_t ldb, double _Complex beta,
                 double _Complex *C, int64_t ldc);
+
+void onemklSsymm(syclQueue_t device_queue, onemklSide left_right,
+                onemklUplo upper_lower, int64_t m, int64_t n,
+                float alpha, const float *a, int64_t lda, const float *b,
+                int64_t ldb, float beta, float *c, int64_t ldc);
+void onemklDsymm(syclQueue_t device_queue, onemklSide left_right,
+                onemklUplo upper_lower, int64_t m, int64_t n,
+                double alpha, const double *a, int64_t lda, const double *b,
+                int64_t ldb, double beta, double *c, int64_t ldc);
+void onemklCsymm(syclQueue_t device_queue, onemklSide left_right,
+                onemklUplo upper_lower, int64_t m, int64_t n,
+                float _Complex alpha, const float _Complex *a, int64_t lda,
+                const float _Complex *b, int64_t ldb, float _Complex beta,
+                float _Complex *c, int64_t ldc);
+void onemklZsymm(syclQueue_t device_queue, onemklSide left_right,
+                onemklUplo upper_lower, int64_t m, int64_t n,
+                double _Complex alpha, const double _Complex *a, int64_t lda,
+                const double _Complex *b, int64_t ldb, double _Complex beta,
+                double _Complex *c, int64_t ldc);
 
 void onemklSgbmv(syclQueue_t device_queue, onemklTranspose trans, int64_t m,
                 int64_t n, int64_t kl, int64_t ku, float alpha, const float *a,

--- a/deps/src/onemkl.h
+++ b/deps/src/onemkl.h
@@ -147,6 +147,15 @@ void onemklZhemm(syclQueue_t device_queue, onemklSide left_right,
                             int64_t lda, const double _Complex *b, int64_t ldb,
                             double _Complex beta, double _Complex *c, int64_t ldc);
 
+void onemklCherk(syclQueue_t device_queue, onemklUplo upper_lower,
+                onemklTranspose trans, int64_t n, int64_t k, float alpha,
+                const float _Complex *a, int64_t lda, float beta,
+                float _Complex *c, int64_t ldc);
+void onemklZherk(syclQueue_t device_queue, onemklUplo upper_lower,
+                onemklTranspose trans, int64_t n, int64_t k, double alpha,
+                const double _Complex *a, int64_t lda, double beta,
+                double _Complex *c, int64_t ldc);
+
 void onemklSgbmv(syclQueue_t device_queue, onemklTranspose trans, int64_t m,
                 int64_t n, int64_t kl, int64_t ku, float alpha, const float *a,
                 int64_t lda, const float *x, int64_t incx, float beta, float *y,

--- a/deps/src/onemkl.h
+++ b/deps/src/onemkl.h
@@ -88,6 +88,21 @@ void onemklZsyrk(syclQueue_t device_queue, onemklUplo upper_lower,
                 const double _Complex *a, int64_t lda, double _Complex beta, double _Complex *c,
                 int64_t ldc);
 
+void onemklSsyr2k(syclQueue_t device_queue, onemklUplo upper_lower, onemklTranspose trans,
+                int64_t n, int64_t k, float alpha, const float *a, int64_t lda,
+                const float *b, int64_t ldb, float beta, float *c, int64_t ldc);
+void onemklDsyr2k(syclQueue_t device_queue, onemklUplo upper_lower, onemklTranspose trans,
+                int64_t n, int64_t k, double alpha, const double *a, int64_t lda,
+                const double *b, int64_t ldb, double beta, double *c, int64_t ldc);
+void onemklCsyr2k(syclQueue_t device_queue, onemklUplo upper_lower, onemklTranspose trans,
+                int64_t n, int64_t k, float _Complex alpha, const float _Complex *a,
+                int64_t lda, const float _Complex *b, int64_t ldb, float _Complex beta,
+                float _Complex *c, int64_t ldc);
+void onemklZsyr2k(syclQueue_t device_queue, onemklUplo upper_lower, onemklTranspose trans,
+                int64_t n, int64_t k, double _Complex alpha, const double _Complex *a,
+                int64_t lda, const double _Complex *b, int64_t ldb, double _Complex beta,
+                double _Complex *c, int64_t ldc);
+
 void onemklSgbmv(syclQueue_t device_queue, onemklTranspose trans, int64_t m,
                 int64_t n, int64_t kl, int64_t ku, float alpha, const float *a,
                 int64_t lda, const float *x, int64_t incx, float beta, float *y,

--- a/deps/src/onemkl.h
+++ b/deps/src/onemkl.h
@@ -103,6 +103,39 @@ void onemklZsyr2k(syclQueue_t device_queue, onemklUplo upper_lower, onemklTransp
                 int64_t lda, const double _Complex *b, int64_t ldb, double _Complex beta,
                 double _Complex *c, int64_t ldc);
 
+void onemklStrmm(syclQueue_t device_queue, onemklSide left_right,
+                onemklUplo uppler_lower, onemklTranspose trans,
+                onemklDiag diag, int64_t m, int64_t n, float alpha,
+                const float *a, int64_t lda, float *b, int64_t ldb);
+void onemklDtrmm(syclQueue_t device_queue, onemklSide left_right,
+                onemklUplo uppler_lower, onemklTranspose trans,
+                onemklDiag diag, int64_t m, int64_t n, double alpha,
+                const double *a, int64_t lda, double *b, int64_t ldb);
+void onemklCtrmm(syclQueue_t device_queue, onemklSide left_right,
+                onemklUplo uppler_lower, onemklTranspose trans,
+                onemklDiag diag, int64_t m, int64_t n, float _Complex alpha,
+                const float _Complex *a, int64_t lda, float _Complex *b,
+                int64_t ldb);
+void onemklZtrmm(syclQueue_t device_queue, onemklSide left_right,
+                onemklUplo uppler_lower, onemklTranspose trans,
+                onemklDiag diag, int64_t m, int64_t n, double _Complex alpha,
+                const double _Complex *a, int64_t lda, double _Complex *b, int64_t ldb);
+
+void onemklStrsm(syclQueue_t device_queue, onemklSide left_right, onemklUplo upper_lower,
+                onemklTranspose transa, onemklDiag unit_diag, int64_t m, int64_t n,
+                float alpha, const float *a, int64_t lda, float *b, int64_t ldb);
+void onemklDtrsm(syclQueue_t device_queue, onemklSide left_right, onemklUplo upper_lower,
+                onemklTranspose transa, onemklDiag unit_diag, int64_t m, int64_t n,
+                double alpha, const double *a, int64_t lda, double *b, int64_t ldb);
+void onemklCtrsm(syclQueue_t device_queue, onemklSide left_right, onemklUplo upper_lower,
+                onemklTranspose transa, onemklDiag unit_diag, int64_t m, int64_t n,
+                float _Complex alpha, const float _Complex *a, int64_t lda, float _Complex *b,
+                int64_t ldb);
+void onemklZtrsm(syclQueue_t device_queue, onemklSide left_right, onemklUplo upper_lower,
+                onemklTranspose transa, onemklDiag unit_diag, int64_t m, int64_t n,
+                double _Complex alpha, const double _Complex *a, int64_t lda, double _Complex *b,
+                int64_t ldb);
+
 void onemklSgbmv(syclQueue_t device_queue, onemklTranspose trans, int64_t m,
                 int64_t n, int64_t kl, int64_t ku, float alpha, const float *a,
                 int64_t lda, const float *x, int64_t incx, float beta, float *y,

--- a/lib/mkl/libonemkl.jl
+++ b/lib/mkl/libonemkl.jl
@@ -147,6 +147,34 @@ function onemklZsyrk(device_queue, upper_lower, trans, n, k, alpha, a, lda, beta
                                          ldc::Int64)::Cvoid
 end
 
+function onemklSsyr2k(device_queue, upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta, c, ldc)
+    @ccall liboneapi_support.onemklSsyr2k(device_queue::syclQueue_t, upper_lower::onemklUplo,
+                                          trans::onemklTranspose, n::Int64, k::Int64, alpha::Cfloat,
+                                          a::ZePtr{Cfloat}, lda::Int64, b::ZePtr{Cfloat}, ldb::Int64,
+                                          beta::Cfloat, c::ZePtr{Cfloat}, ldc::Int64)::Cvoid
+end
+
+function onemklDsyr2k(device_queue, upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta, c, ldc)
+    @ccall liboneapi_support.onemklDsyr2k(device_queue::syclQueue_t, upper_lower::onemklUplo,
+                                          trans::onemklTranspose, n::Int64, k::Int64, alpha::Cdouble,
+                                          a::ZePtr{Cdouble}, lda::Int64, b::ZePtr{Cdouble}, ldb::Int64,
+                                          beta::Cdouble, c::ZePtr{Cdouble}, ldc::Int64)::Cvoid
+end
+
+function onemklCsyr2k(device_queue, upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta, c, ldc)
+    @ccall liboneapi_support.onemklCsyr2k(device_queue::syclQueue_t, upper_lower::onemklUplo,
+                                          trans::onemklTranspose, n::Int64, k::Int64, alpha::ComplexF32,
+                                          a::ZePtr{ComplexF32}, lda::Int64, b::ZePtr{ComplexF32}, ldb::Int64,
+                                          beta::ComplexF32, c::ZePtr{ComplexF32}, ldc::Int64)::Cvoid
+end
+
+function onemklZsyr2k(device_queue, upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta, c, ldc)
+    @ccall liboneapi_support.onemklZsyr2k(device_queue::syclQueue_t, upper_lower::onemklUplo,
+                                          trans::onemklTranspose, n::Int64, k::Int64, alpha::ComplexF64,
+                                          a::ZePtr{ComplexF64}, lda::Int64, b::ZePtr{ComplexF64}, ldb::Int64,
+                                          beta::ComplexF64, c::ZePtr{ComplexF64}, ldc::Int64)::Cvoid
+end
+
 function onemklSdot(device_queue, n, x, incx, y, incy, result)
     @ccall liboneapi_support.onemklSdot(device_queue::syclQueue_t, n::Int64,
                                         x::ZePtr{Cfloat}, incx::Int64, y::ZePtr{Cfloat},

--- a/lib/mkl/libonemkl.jl
+++ b/lib/mkl/libonemkl.jl
@@ -119,6 +119,34 @@ function onemklZsymm(device_queue, left_right, upper_lower, m, n, alpha, a, lda,
                                         ldc::Int64)::Cvoid
 end
 
+function onemklSsyrk(device_queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc)
+    @ccall liboneapi_support.onemklSsyrk(device_queue::syclQueue_t, upper_lower::onemklUplo,
+                                         trans::onemklTranspose, n::Int64, k::Int64, alpha::Cfloat,
+                                         a::ZePtr{Cfloat}, lda::Int64, beta::Cfloat, c::ZePtr{Cfloat},
+                                         ldc::Int64)::Cvoid
+end
+
+function onemklDsyrk(device_queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc)
+    @ccall liboneapi_support.onemklDsyrk(device_queue::syclQueue_t, upper_lower::onemklUplo,
+                                         trans::onemklTranspose, n::Int64, k::Int64, alpha::Cdouble,
+                                         a::ZePtr{Cdouble}, lda::Int64, beta::Cdouble, c::ZePtr{Cdouble},
+                                         ldc::Int64)::Cvoid
+end
+
+function onemklCsyrk(device_queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc)
+    @ccall liboneapi_support.onemklCsyrk(device_queue::syclQueue_t, upper_lower::onemklUplo,
+                                         trans::onemklTranspose, n::Int64, k::Int64, alpha::ComplexF32,
+                                         a::ZePtr{ComplexF32}, lda::Int64, beta::ComplexF32, c::ZePtr{ComplexF32},
+                                         ldc::Int64)::Cvoid
+end
+
+function onemklZsyrk(device_queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc)
+    @ccall liboneapi_support.onemklZsyrk(device_queue::syclQueue_t, upper_lower::onemklUplo,
+                                         trans::onemklTranspose, n::Int64, k::Int64, alpha::ComplexF64,
+                                         a::ZePtr{ComplexF64}, lda::Int64, beta::ComplexF64, c::ZePtr{ComplexF64},
+                                         ldc::Int64)::Cvoid
+end
+
 function onemklSdot(device_queue, n, x, incx, y, incy, result)
     @ccall liboneapi_support.onemklSdot(device_queue::syclQueue_t, n::Int64,
                                         x::ZePtr{Cfloat}, incx::Int64, y::ZePtr{Cfloat},

--- a/lib/mkl/libonemkl.jl
+++ b/lib/mkl/libonemkl.jl
@@ -239,6 +239,22 @@ function onemklZtrsm(device_queue, left_right, upper_lower, transa, unit_diag, m
                                          ldb::Int64)::Cvoid
 end
 
+function onemklChemm(device_queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
+                     beta, c, ldc)
+    @ccall liboneapi_support.onemklChemm(device_queue::syclQueue_t, left_right::onemklSide,
+                                         upper_lower::onemklUplo, m::Int64, n::Int64, alpha::ComplexF32,
+                                         a::ZePtr{ComplexF32}, lda::Int64, b::ZePtr{ComplexF32}, ldb::Int64,
+                                         beta::ComplexF32, c::ZePtr{ComplexF32}, ldc::Int64)::Cvoid
+end
+
+function onemklZhemm(device_queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
+                    beta, c, ldc)
+    @ccall liboneapi_support.onemklZhemm(device_queue::syclQueue_t, left_right::onemklSide,
+                                        upper_lower::onemklUplo, m::Int64, n::Int64, alpha::ComplexF64,
+                                        a::ZePtr{ComplexF64}, lda::Int64, b::ZePtr{ComplexF64}, ldb::Int64,
+                                        beta::ComplexF64, c::ZePtr{ComplexF64}, ldc::Int64)::Cvoid
+end
+
 function onemklSdot(device_queue, n, x, incx, y, incy, result)
     @ccall liboneapi_support.onemklSdot(device_queue::syclQueue_t, n::Int64,
                                         x::ZePtr{Cfloat}, incx::Int64, y::ZePtr{Cfloat},

--- a/lib/mkl/libonemkl.jl
+++ b/lib/mkl/libonemkl.jl
@@ -269,6 +269,20 @@ function onemklZherk(device_queue, upper_lower, trans, n, k, alpha, a, lda, beta
                                          c::ZePtr{ComplexF64}, ldc::Int64)::Cvoid
 end
 
+function onemklCher2k(device_queue, upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta, c, ldc)
+    @ccall liboneapi_support.onemklCher2k(device_queue::syclQueue_t, upper_lower::onemklUplo,
+                                          trans::onemklTranspose, n::Int64, k::Int64, alpha::ComplexF32,
+                                          a::ZePtr{ComplexF32}, lda::Int64, b::ZePtr{ComplexF32}, ldb::Int64,
+                                          beta::Cfloat, c::ZePtr{ComplexF32}, ldc::Int64)::Cvoid
+end
+
+function onemklZher2k(device_queue, upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta, c, ldc)
+    @ccall liboneapi_support.onemklZher2k(device_queue::syclQueue_t, upper_lower::onemklUplo,
+                                          trans::onemklTranspose, n::Int64, k::Int64, alpha::ComplexF64,
+                                          a::ZePtr{ComplexF64}, lda::Int64, b::ZePtr{ComplexF64}, ldb::Int64,
+                                          beta::Cdouble, c::ZePtr{ComplexF64}, ldc::Int64)::Cvoid
+end
+
 function onemklSdot(device_queue, n, x, incx, y, incy, result)
     @ccall liboneapi_support.onemklSdot(device_queue::syclQueue_t, n::Int64,
                                         x::ZePtr{Cfloat}, incx::Int64, y::ZePtr{Cfloat},

--- a/lib/mkl/libonemkl.jl
+++ b/lib/mkl/libonemkl.jl
@@ -175,6 +175,70 @@ function onemklZsyr2k(device_queue, upper_lower, trans, n, k, alpha, a, lda, b, 
                                           beta::ComplexF64, c::ZePtr{ComplexF64}, ldc::Int64)::Cvoid
 end
 
+function onemklStrmm(device_queue, left_right, upper_lower, trana, unit_diag, m, n, alpha,
+                     a, lda, b, ldb)
+    @ccall liboneapi_support.onemklStrmm(device_queue::syclQueue_t, left_right::onemklSide,
+                                         upper_lower::onemklUplo, trana::onemklTranspose,
+                                         unit_diag::onemklDiag, m::Int64, n::Int64, alpha::Cfloat,
+                                         a::ZePtr{Cfloat}, lda::Int64, b::ZePtr{Cfloat}, ldb::Int64)::Cvoid
+end
+
+function onemklDtrmm(device_queue, left_right, upper_lower, trana, unit_diag, m, n, alpha,
+                    a, lda, b, ldb)
+    @ccall liboneapi_support.onemklDtrmm(device_queue::syclQueue_t, left_right::onemklSide,
+                                        upper_lower::onemklUplo, trana::onemklTranspose,
+                                        unit_diag::onemklDiag, m::Int64, n::Int64, alpha::Cdouble,
+                                        a::ZePtr{Cdouble}, lda::Int64, b::ZePtr{Cdouble}, ldb::Int64)::Cvoid
+end
+
+function onemklCtrmm(device_queue, left_right, upper_lower, trana, unit_diag, m, n, alpha,
+                    a, lda, b, ldb)
+    @ccall liboneapi_support.onemklCtrmm(device_queue::syclQueue_t, left_right::onemklSide,
+                                        upper_lower::onemklUplo, trana::onemklTranspose,
+                                        unit_diag::onemklDiag, m::Int64, n::Int64, alpha::ComplexF32,
+                                        a::ZePtr{ComplexF32}, lda::Int64, b::ZePtr{ComplexF32}, ldb::Int64)::Cvoid
+end
+
+function onemklZtrmm(device_queue, left_right, upper_lower, trana, unit_diag, m, n, alpha,
+                    a, lda, b, ldb)
+    @ccall liboneapi_support.onemklZtrmm(device_queue::syclQueue_t, left_right::onemklSide,
+                                        upper_lower::onemklUplo, trana::onemklTranspose,
+                                        unit_diag::onemklDiag, m::Int64, n::Int64, alpha::ComplexF64,
+                                        a::ZePtr{ComplexF64}, lda::Int64, b::ZePtr{ComplexF64}, ldb::Int64)::Cvoid
+end
+
+function onemklStrsm(device_queue, left_right, upper_lower, transa, unit_diag, m, n, alpha, a, lda, b, ldb)
+    @ccall liboneapi_support.onemklStrsm(device_queue::syclQueue_t, left_right::onemklSide,
+                                         upper_lower::onemklUplo, transa::onemklTranspose,
+                                         unit_diag::onemklDiag, m::Int64, n::Int64, alpha::Cfloat,
+                                         a::ZePtr{Cfloat}, lda::Int64, b::ZePtr{Cfloat},
+                                         ldb::Int64)::Cvoid
+end
+
+function onemklDtrsm(device_queue, left_right, upper_lower, transa, unit_diag, m, n, alpha, a, lda, b, ldb)
+    @ccall liboneapi_support.onemklDtrsm(device_queue::syclQueue_t, left_right::onemklSide,
+                                         upper_lower::onemklUplo, transa::onemklTranspose,
+                                         unit_diag::onemklDiag, m::Int64, n::Int64, alpha::Cdouble,
+                                         a::ZePtr{Cdouble}, lda::Int64, b::ZePtr{Cdouble},
+                                         ldb::Int64)::Cvoid
+end
+
+function onemklCtrsm(device_queue, left_right, upper_lower, transa, unit_diag, m, n, alpha, a, lda, b, ldb)
+    @ccall liboneapi_support.onemklCtrsm(device_queue::syclQueue_t, left_right::onemklSide,
+                                         upper_lower::onemklUplo, transa::onemklTranspose,
+                                         unit_diag::onemklDiag, m::Int64, n::Int64, alpha::ComplexF32,
+                                         a::ZePtr{ComplexF32}, lda::Int64, b::ZePtr{ComplexF32},
+                                         ldb::Int64)::Cvoid
+end
+
+function onemklZtrsm(device_queue, left_right, upper_lower, transa, unit_diag, m, n, alpha, a, lda, b, ldb)
+    @ccall liboneapi_support.onemklZtrsm(device_queue::syclQueue_t, left_right::onemklSide,
+                                         upper_lower::onemklUplo, transa::onemklTranspose,
+                                         unit_diag::onemklDiag, m::Int64, n::Int64, alpha::ComplexF64,
+                                         a::ZePtr{ComplexF64}, lda::Int64, b::ZePtr{ComplexF64},
+                                         ldb::Int64)::Cvoid
+end
+
 function onemklSdot(device_queue, n, x, incx, y, incy, result)
     @ccall liboneapi_support.onemklSdot(device_queue::syclQueue_t, n::Int64,
                                         x::ZePtr{Cfloat}, incx::Int64, y::ZePtr{Cfloat},

--- a/lib/mkl/libonemkl.jl
+++ b/lib/mkl/libonemkl.jl
@@ -16,6 +16,11 @@ end
     ONEMKL_DIAG_UNIT = 1
 end
 
+@cenum onemklSide::UInt32 begin
+    ONEMKL_SIDE_LEFT = 0
+    ONEMKL_SIDE_RIGHT = 1
+end
+
 function onemklSgbmv(device_queue, trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y, incy)
     @ccall liboneapi_support.onemklSgbmv(device_queue::syclQueue_t, trans::onemklTranspose, 
                                         m::Int64, n::Int64, kl::Int64, ku::Int64, alpha::Cfloat,
@@ -78,6 +83,40 @@ function onemklZgemm(device_queue, transA, transB, m, n, k, alpha, A, lda, B, ld
                                     alpha::ComplexF64, A::ZePtr{ComplexF64}, lda::Int64,
                                     B::ZePtr{ComplexF64}, ldb::Int64, beta::ComplexF64,
                                     C::ZePtr{ComplexF64}, ldc::Int64)::Cint
+end
+
+function onemklSsymm(device_queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, beta,
+                     c, ldc) 
+    @ccall liboneapi_support.onemklSsymm(device_queue::syclQueue_t, left_right::onemklSide,
+                                         upper_lower::onemklUplo, m::Int64, n::Int64, alpha::Cfloat,
+                                         a::ZePtr{Cfloat}, lda::Int64, b::ZePtr{Cfloat}, ldb::Int64,
+                                         beta::Cfloat, c::ZePtr{Cfloat}, ldc::Int64)::Cvoid
+end
+
+function onemklDsymm(device_queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, beta,
+                    c, ldc) 
+    @ccall liboneapi_support.onemklDsymm(device_queue::syclQueue_t, left_right::onemklSide,
+                                        upper_lower::onemklUplo, m::Int64, n::Int64, alpha::Cdouble,
+                                        a::ZePtr{Cdouble}, lda::Int64, b::ZePtr{Cdouble}, ldb::Int64,
+                                        beta::Cdouble, c::ZePtr{Cdouble}, ldc::Int64)::Cvoid
+end
+
+function onemklCsymm(device_queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, beta,
+                     c, ldc) 
+    @ccall liboneapi_support.onemklCsymm(device_queue::syclQueue_t, left_right::onemklSide,
+                                        upper_lower::onemklUplo, m::Int64, n::Int64, alpha::ComplexF32,
+                                        a::ZePtr{ComplexF32}, lda::Int64, b::ZePtr{ComplexF32},
+                                        ldb::Int64, beta::ComplexF32, c::ZePtr{ComplexF32},
+                                        ldc::Int64)::Cvoid
+end
+
+function onemklZsymm(device_queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, beta,
+                     c, ldc) 
+    @ccall liboneapi_support.onemklZsymm(device_queue::syclQueue_t, left_right::onemklSide,
+                                        upper_lower::onemklUplo, m::Int64, n::Int64, alpha::ComplexF64,
+                                        a::ZePtr{ComplexF64}, lda::Int64, b::ZePtr{ComplexF64},
+                                        ldb::Int64, beta::ComplexF64, c::ZePtr{ComplexF64},
+                                        ldc::Int64)::Cvoid
 end
 
 function onemklSdot(device_queue, n, x, incx, y, incy, result)
@@ -528,3 +567,4 @@ function onemklZswap(device_queue, n, x, incx, y, incy)
                                     x::ZePtr{ComplexF64}, incx::Cint,
                                     y::ZePtr{ComplexF64}, incy::Cint)::Cvoid
 end
+

--- a/lib/mkl/libonemkl.jl
+++ b/lib/mkl/libonemkl.jl
@@ -255,6 +255,20 @@ function onemklZhemm(device_queue, left_right, upper_lower, m, n, alpha, a, lda,
                                         beta::ComplexF64, c::ZePtr{ComplexF64}, ldc::Int64)::Cvoid
 end
 
+function onemklCherk(device_queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc)
+    @ccall liboneapi_support.onemklCherk(device_queue::syclQueue_t, upper_lower::onemklUplo,
+                                         trans::onemklTranspose, n::Int64, k::Int64, alpha::Cfloat,
+                                         a::ZePtr{ComplexF32}, lda::Int64, beta::Cfloat,
+                                         c::ZePtr{ComplexF32}, ldc::Int64)::Cvoid
+end
+
+function onemklZherk(device_queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc)
+    @ccall liboneapi_support.onemklZherk(device_queue::syclQueue_t, upper_lower::onemklUplo,
+                                         trans::onemklTranspose, n::Int64, k::Int64, alpha::Cdouble,
+                                         a::ZePtr{ComplexF64}, lda::Int64, beta::Cdouble,
+                                         c::ZePtr{ComplexF64}, ldc::Int64)::Cvoid
+end
+
 function onemklSdot(device_queue, n, x, incx, y, incy, result)
     @ccall liboneapi_support.onemklSdot(device_queue::syclQueue_t, n::Int64,
                                         x::ZePtr{Cfloat}, incx::Int64, y::ZePtr{Cfloat},

--- a/lib/mkl/oneMKL.jl
+++ b/lib/mkl/oneMKL.jl
@@ -14,7 +14,7 @@ include("libonemkl.jl")
 
 # Exclude Float16 for now, since many oneMKL functions - copy, scal, do not take Float16
 const onemklFloat = Union{Float64,Float32,ComplexF64,ComplexF32}
-
+const onemklComplex = Union{ComplexF32,ComplexF64}
 include("wrappers.jl")
 include("linalg.jl")
 

--- a/lib/mkl/wrappers.jl
+++ b/lib/mkl/wrappers.jl
@@ -2,6 +2,16 @@
 # Auxiliary
 #
 
+function Base.convert(::Type{onemklSide}, side::Char)
+    if side == 'L'
+        return ONEMKL_SIDE_LEFT
+    elseif side == 'R'
+        return ONEMKL_SIDE_RIGHT
+    else
+        throw(ArgumentError("Unknown transpose $side"))
+    end
+end
+
 function Base.convert(::Type{onemklTranspose}, trans::Char)
     if trans == 'N'
         return ONEMKL_TRANSPOSE_NONTRANS
@@ -31,6 +41,52 @@ function Base.convert(::Type{onemklDiag}, diag::Char)
         return ONEMKL_DIAG_UNIT
     else
         throw(ArgumentError("Unknown transpose $diag"))
+    end
+end
+
+## (L3: symm) symmetric matrix-matrix and matrix-vector multiplication
+for (fname, elty) in ((:onemklSsymm, :Float32),
+                      (:onemklDsymm, :Float64),
+                      (:onemklCsymm, :ComplexF32),
+                      (:onemklZsymm, :ComplexF64))
+    @eval begin
+        function symm!(side::Char,
+                       uplo::Char,
+                       alpha::Number,
+                       A::oneStridedVecOrMat{$elty},
+                       B::oneStridedVecOrMat{$elty},
+                       beta::Number,
+                       C::oneStridedVecOrMat{$elty})
+            k, nA = size(A)
+            if k != nA throw(DimensionMismatch("Matrix A must be square")) end
+            m = side == 'L' ? k : size(B,1)
+            n = side == 'L' ? size(B,2) : k
+            if m != size(C,1) || n != size(C,2) || k != size(B, side == 'L' ? 1 : 2)
+                throw(DimensionMismatch(""))
+            end
+            lda = max(1,stride(A,2))
+            ldb = max(1,stride(B,2))
+            ldc = max(1,stride(C,2))
+            queue = global_queue(context(A), device(A))
+            $fname(sycl_queue(queue), side, uplo, m, n, alpha, A, lda, B, ldb,
+                   beta, C, ldc)
+            C
+        end
+
+        function symm(side::Char,
+                      uplo::Char,
+                      alpha::Number,
+                      A::oneStridedVecOrMat{$elty},
+                      B::oneStridedVecOrMat{$elty})
+            symm!(side, uplo, alpha, A, B, zero($elty), similar(B))
+        end
+
+        function symm(side::Char,
+                      uplo::Char,
+                      A::oneStridedVecOrMat{$elty},
+                      B::oneStridedVecOrMat{$elty})
+            symm(side, uplo, one($elty), A, B)
+        end
     end
 end
 

--- a/test/onemkl.jl
+++ b/test/onemkl.jl
@@ -518,3 +518,37 @@ end
         end
     end
 end
+
+@testset "level 3" begin
+    @testset for T in intersect(eltypes, [Float32, Float64, ComplexF32, ComplexF64])
+        alpha = rand(T)
+        beta = rand(T)
+        B = rand(T,m,n)
+        C = rand(T,m,n)
+        Bbad = rand(T,m+1,n+1)
+        d_B = oneArray(B)
+        d_C = oneArray(C)
+        d_Bbad = oneArray(Bbad)
+        sA = rand(T,m,m)
+        sA = sA + transpose(sA)
+        dsA = oneArray(sA)
+
+        @testset "symm!" begin
+            oneMKL.symm!('L','U',alpha,dsA,d_B,beta,d_C)
+            C = (alpha*sA)*B + beta*C
+            # compare
+            h_C = Array(d_C)
+            @test C ≈ h_C
+            @test_throws DimensionMismatch oneMKL.symm!('L','U',alpha,dsA,d_Bbad,beta,d_C)
+        end
+
+        @testset "symm" begin
+            d_C = oneMKL.symm('L','U',dsA,d_B)
+            C = sA*B
+            # compare
+            h_C = Array(d_C)
+            @test C ≈ h_C
+            @test_throws DimensionMismatch oneMKL.symm('L','U',dsA,d_Bbad)
+        end
+    end
+end

--- a/test/onemkl.jl
+++ b/test/onemkl.jl
@@ -606,6 +606,7 @@ end
             h_C = Array(dB)
             @test C ≈ h_C
         end
+
         @testset "trmm" begin
             A = triu(rand(T, m, m))
             B = rand(T,m,n)
@@ -684,6 +685,39 @@ end
                 C = alpha*(A/transpose(B))
                 dC = oneMKL.trsm('R','U','T','N',alpha,dB,dA)
                 @test C ≈ Array(dC)
+            end
+        end
+        if T <:Union{ComplexF32,ComplexF64}
+            @testset "hemm!" begin
+                B = rand(T,m,n)
+                C = rand(T,m,n)
+                d_B = oneArray(B)
+                d_C = oneArray(C)
+                hA = rand(T,m,m)
+                hA = hA + hA'
+                dhA = oneArray(hA)
+                # compute
+                C = alpha*(hA*B) + beta*C
+                oneMKL.hemm!('L','L',alpha,dhA,d_B,beta,d_C)
+                # move to host and compare
+                h_C = Array(d_C)
+                @test C ≈ h_C
+            end
+
+            @testset "hemm" begin
+                B = rand(T,m,n)
+                C = rand(T,m,n)
+                d_B = oneArray(B)
+                d_C = oneArray(C)
+                hA = rand(T,m,m)
+                hA = hA + hA'
+                dhA = oneArray(hA)
+
+                C = hA*B
+                d_C = oneMKL.hemm('L','U',dhA,d_B)
+                # move to host and compare
+                h_C = Array(d_C)
+                @test C ≈ h_C
             end
         end
     end

--- a/test/onemkl.jl
+++ b/test/onemkl.jl
@@ -594,5 +594,97 @@ end
             h_C = triu(h_C)
             @test C ≈ h_C
         end
+
+        @testset "trmm!" begin
+            A = triu(rand(T, m, m))
+            B = rand(T,m,n)
+            dA = oneArray(A)
+            dB = oneArray(B)
+            C = alpha*A*B
+            oneMKL.trmm!('L','U','N','N',alpha,dA,dB)
+            # move to host and compare
+            h_C = Array(dB)
+            @test C ≈ h_C
+        end
+        @testset "trmm" begin
+            A = triu(rand(T, m, m))
+            B = rand(T,m,n)
+            dA = oneArray(A)
+            dB = oneArray(B)
+            C = alpha*A*B
+            oneMKL.trmm('L','U','N','N',alpha,dA,dB)
+            # move to host and compare
+            h_C = Array(dB)
+            @test C ≈ h_C
+        end
+
+        @testset "left trsm!" begin
+            A = triu(rand(T, m, m))
+            B = rand(T,m,n)
+            dA = oneArray(A)
+            dB = oneArray(B)
+            C = alpha*(A\B)
+            dC = copy(dB)
+            oneMKL.trsm!('L','U','N','N',alpha,dA,dC)
+            @test C ≈ Array(dC)
+        end
+
+        @testset "left trsm" begin
+            A = triu(rand(T, m, m))
+            B = rand(T,m,n)
+            dA = oneArray(A)
+            dB = oneArray(B)
+            C = alpha*(A\B)
+            dC = oneMKL.trsm('L','U','N','N',alpha,dA,dB)
+            @test C ≈ Array(dC)
+        end
+
+        @testset "left trsm (adjoint)" begin
+            A = triu(rand(T, m, m))
+            B = rand(T,m,n)
+            dA = oneArray(A)
+            dB = oneArray(B)
+            C = alpha*(adjoint(A)\B)
+            dC = oneMKL.trsm('L','U','C','N',alpha,dA,dB)
+            @test C ≈ Array(dC)
+        end
+
+        @testset "left trsm (transpose)" begin
+            A = triu(rand(T, m, m))
+            B = rand(T,m,n)
+            dA = oneArray(A)
+            dB = oneArray(B)
+            C = alpha*(transpose(A)\B)
+            dC = oneMKL.trsm('L','U','T','N',alpha,dA,dB)
+            @test C ≈ Array(dC)
+        end
+
+        let A = rand(T, m,m), B = triu(rand(T, m, m)), alpha = rand(T)
+            dA = oneArray(A)
+            dB = oneArray(B)
+
+            @testset "right trsm!" begin
+                C = alpha*(A/B)
+                dC = copy(dA)
+                oneMKL.trsm!('R','U','N','N',alpha,dB,dC)
+                @test C ≈ Array(dC)
+            end
+
+            @testset "right trsm" begin
+                C = alpha*(A/B)
+                dC = oneMKL.trsm('R','U','N','N',alpha,dB,dA)
+                @test C ≈ Array(dC)
+            end
+            @testset "right trsm (adjoint)" begin
+                C = alpha*(A/adjoint(B))
+                dC = oneMKL.trsm('R','U','C','N',alpha,dB,dA)
+                @test C ≈ Array(dC)
+            end
+            @testset "right trsm (transpose)" begin
+                C = alpha*(A/transpose(B))
+                dC = oneMKL.trsm('R','U','T','N',alpha,dB,dA)
+                @test C ≈ Array(dC)
+            end
+        end
     end
 end

--- a/test/onemkl.jl
+++ b/test/onemkl.jl
@@ -758,6 +758,54 @@ end
                 h_C = triu(C)
                 @test C ≈ h_C
             end
+
+            @testset "her2k!" begin
+                A = rand(T,m,k)
+                B = rand(T,m,k)
+                Bbad = rand(T,m+1,k+1)
+                C = rand(T,m,m)
+                C = C + transpose(C)
+                # move to device
+                d_A = oneArray(A)
+                d_B = oneArray(B)
+                d_Bbad = oneArray(Bbad)
+                d_C = oneArray(C)
+                elty1 = T
+                elty2 = real(T)
+                # generate parameters
+                α = rand(elty1)
+                β = rand(elty2)
+                C = C + C'
+                d_C = oneArray(C)
+                C = α*(A*B') + conj(α)*(B*A') + β*C
+                oneMKL.her2k!('U','N',α,d_A,d_B,β,d_C)
+                # move back to host and compare
+                C = triu(C)
+                h_C = Array(d_C)
+                h_C = triu(h_C)
+                @test C ≈ h_C
+                @test_throws DimensionMismatch oneMKL.her2k!('U','N',α,d_A,d_Bbad,β,d_C)
+            end
+    
+            @testset "her2k" begin
+                A = rand(T,m,k)
+                B = rand(T,m,k)
+                Bbad = rand(T,m+1,k+1)
+                C = rand(T,m,m)
+                C = C + transpose(C)
+                # move to device
+                d_A = oneArray(A)
+                d_B = oneArray(B)
+                d_Bbad = oneArray(Bbad)
+                d_C = oneArray(C)
+                C = A*B' + B*A'
+                d_C = oneMKL.her2k('U','N',d_A,d_B)
+                # move back to host and compare
+                C = triu(C)
+                h_C = Array(d_C)
+                h_C = triu(h_C)
+                @test C ≈ h_C
+            end
         end
     end
 end

--- a/test/onemkl.jl
+++ b/test/onemkl.jl
@@ -550,5 +550,17 @@ end
             @test C ≈ h_C
             @test_throws DimensionMismatch oneMKL.symm('L','U',dsA,d_Bbad)
         end
+
+        @testset "syrk" begin
+            A = rand(T,m,k)
+            d_A = oneArray(A)
+            d_C = oneMKL.syrk('U','N',d_A)
+            C = A*transpose(A)
+            C = triu(C)
+            # move to host and compare
+            h_C = Array(d_C)
+            h_C = triu(C)
+            @test C ≈ h_C
+        end
     end
 end

--- a/test/onemkl.jl
+++ b/test/onemkl.jl
@@ -562,5 +562,37 @@ end
             h_C = triu(C)
             @test C ≈ h_C
         end
+
+        A = rand(T,m,k)
+        B = rand(T,m,k)
+        Bbad = rand(T,m+1,k+1)
+        C = rand(T,m,m)
+        C = C + transpose(C)
+        # move to device
+        d_A = oneArray(A)
+        d_B = oneArray(B)
+        d_Bbad = oneArray(Bbad)
+        d_C = oneArray(C)
+        @testset "syr2k!" begin
+            # compute
+            C = alpha*(A*transpose(B) + B*transpose(A)) + beta*C
+            oneMKL.syr2k!('U','N',alpha,d_A,d_B,beta,d_C)
+            # move back to host and compare
+            C = triu(C)
+            h_C = Array(d_C)
+            h_C = triu(h_C)
+            @test C ≈ h_C
+            @test_throws DimensionMismatch oneMKL.syr2k!('U','N',alpha,d_A,d_Bbad,beta,d_C)
+        end
+
+        @testset "syr2k" begin
+            C = alpha*(A*transpose(B) + B*transpose(A))
+            d_C = oneMKL.syr2k('U','N',alpha,d_A,d_B)
+            # move back to host and compare
+            C = triu(C)
+            h_C = Array(d_C)
+            h_C = triu(h_C)
+            @test C ≈ h_C
+        end
     end
 end

--- a/test/onemkl.jl
+++ b/test/onemkl.jl
@@ -719,6 +719,45 @@ end
                 h_C = Array(d_C)
                 @test C ≈ h_C
             end
+
+            @testset "herk!" begin
+                B = rand(T,m,n)
+                C = rand(T,m,n)
+                d_B = oneArray(B)
+                d_C = oneArray(C)
+                hA = rand(T,m,m)
+                hA = hA + hA'
+                dhA = oneArray(hA)
+                A = rand(T,m,k)
+                d_A = oneArray(A)
+                d_C = oneArray(dhA)
+                oneMKL.herk!('U','N',real(alpha),d_A,real(beta),d_C)
+                C = real(alpha)*(A*A') + real(beta)*hA
+                C = triu(C)
+                # move to host and compare
+                h_C = Array(d_C)
+                h_C = triu(C)
+                @test C ≈ h_C
+            end
+    
+            @testset "herk" begin
+                B = rand(T,m,n)
+                C = rand(T,m,n)
+                d_B = oneArray(B)
+                d_C = oneArray(C)
+                hA = rand(T,m,m)
+                hA = hA + hA'
+                dhA = oneArray(hA)
+                A = rand(T,m,k)
+                d_A = oneArray(A)
+                d_C = oneMKL.herk('U','N',d_A)
+                C = A*A'
+                C = triu(C)
+                # move to host and compare
+                h_C = Array(d_C)
+                h_C = triu(C)
+                @test C ≈ h_C
+            end
         end
     end
 end


### PR DESCRIPTION
Following primitives are supported in level-3

Symmetric: symm, syrk, syr2k
Triangular: trmm, trsm
Hermitian: hemm, herk, her2k