### PR TITLE
Update onemklDestory() to call the public mkl_free_buffers() to clean…

### DIFF
--- a/deps/src/onemkl.cpp
+++ b/deps/src/onemkl.cpp
@@ -1098,17 +1098,8 @@ extern "C" void onemklZswap(syclQueue_t device_queue, int64_t n, double _Complex
 // other
 
 // oneMKL keeps a cache of SYCL queues and tries to destroy them when unloading the library.
-// that is incompatible with oneAPI.jl destroying queues before that, so expose a function
+// that is incompatible with oneAPI.jl destroying queues before that, so call mkl_free_buffers()
 // to manually wipe the device cache when we're destroying queues.
-
-namespace oneapi {
-namespace mkl {
-namespace gpu {
-int clean_gpu_caches();
-}
-}
-}
-
 extern "C" void onemklDestroy() {
-    oneapi::mkl::gpu::clean_gpu_caches();
+    mkl_free_buffers();
 }


### PR DESCRIPTION
… up with oneMKL 2023.0.0.  This removes a workaround for the older release of oneMKL.