### PR TITLE
Preserve the buffer type when broadcasting.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,10 +25,10 @@ oneAPI_Level_Zero_Loader_jll = "13eca655-d68d-5b81-8367-6d99d727ab01"
 oneAPI_Support_jll = "b049733a-a71d-5ed3-8eba-7d323ac00b36"
 
 [compat]
-Adapt = "2.0, 3.0"
+Adapt = "4"
 CEnum = "0.4, 0.5"
 ExprTools = "0.1"
-GPUArrays = "9"
+GPUArrays = "10"
 GPUCompiler = "0.23, 0.24, 0.25"
 KernelAbstractions = "0.9.1"
 LLVM = "6"

--- a/src/oneAPI.jl
+++ b/src/oneAPI.jl
@@ -44,15 +44,15 @@ include("device/quirks.jl")
 # essential stuff
 include("context.jl")
 
-# compiler implementation
-include("compiler/compilation.jl")
-include("compiler/execution.jl")
-include("compiler/reflection.jl")
-
 # array abstraction
 include("memory.jl")
 include("pool.jl")
 include("array.jl")
+
+# compiler implementation
+include("compiler/compilation.jl")
+include("compiler/execution.jl")
+include("compiler/reflection.jl")
 
 # array libraries
 include("../lib/mkl/oneMKL.jl")

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -18,13 +18,20 @@ function allocate(::Type{oneL0.SharedBuffer}, ctx, dev, bytes::Int, alignment::I
     return buf
 end
 
+function allocate(::Type{oneL0.HostBuffer}, ctx, dev, bytes::Int, alignment::Int)
+    bytes == 0 && return oneL0.HostBuffer(ZE_NULL, bytes, ctx)
+    host_alloc(ctx, bytes, alignment)
+end
+
 function release(buf::oneL0.AbstractBuffer)
     sizeof(buf) == 0 && return
 
-    ctx = oneL0.context(buf)
-    dev = oneL0.device(buf)
+    if buf isa oneL0.DeviceBuffer || buf isa oneL0.SharedBuffer
+        ctx = oneL0.context(buf)
+        dev = oneL0.device(buf)
+        evict(ctx, dev, buf)
+    end
 
-    evict(ctx, dev, buf)
     free(buf; policy=oneL0.ZE_DRIVER_MEMORY_FREE_POLICY_EXT_FLAG_BLOCKING_FREE)
 
     # TODO: queue-ordered free from non-finalizer tasks once we have


### PR DESCRIPTION
Similar to https://github.com/JuliaGPU/Metal.jl/pull/273 and https://github.com/JuliaGPU/CUDA.jl/pull/2203. To test this, I added some minimal wrappers for host memory, but it isn't functional yet.