### PR TITLE
Enable oneAPI 2024.0.0 support.

### DIFF
--- a/deps/build_local.jl
+++ b/deps/build_local.jl
@@ -40,7 +40,7 @@ if !isfile(joinpath(conda_dir, "condarc-julia.yml"))
     mkpath(joinpath(conda_dir, "conda-meta"))
     touch(joinpath(conda_dir, "conda-meta", "history"))
 end
-Conda.add(["dpcpp_linux-64=2023.0.0", "mkl-devel-dpcpp=2023.0.0"], conda_dir;
+Conda.add(["dpcpp_linux-64=2024.0.0", "mkl-devel-dpcpp=2024.0.0"], conda_dir;
           channel="intel")
 
 Conda.list(conda_dir)

--- a/deps/src/sycl.cpp
+++ b/deps/src/sycl.cpp
@@ -51,7 +51,7 @@ extern "C" int syclQueueCreate(syclQueue_t *obj, syclContext_t context,
                                syclDevice_t device,
                                ze_command_queue_handle_t queue,
                                int keep_ownership) {
-    auto sycl_queue = sycl::ext::oneapi::level_zero::make_queue(context->val, device->val, (pi_native_handle) queue, keep_ownership);
+    auto sycl_queue = sycl::ext::oneapi::level_zero::make_queue(context->val, device->val, (pi_native_handle) queue, false, keep_ownership, {});
     *obj = new syclQueue_st({sycl_queue});
     return 0;
 }


### PR DESCRIPTION
This enables oneAPI 2024 support for oneAPI.jl. 
@maleadt Please update the artifactory to pick dpcpp_linux-64=2024.0.0 and mkl-devel-dpcpp=2024.0.0 as well. 