### PR TITLE
Upgrade the C interface for oneAPI 2024.1.0

### DIFF
--- a/deps/Project.toml
+++ b/deps/Project.toml
@@ -12,4 +12,4 @@ oneAPI_Level_Zero_Headers_jll = "f4bc562b-d309-54f8-9efb-476e56f0410d"
 oneAPI_Support_Headers_jll = "24f86df5-245d-5634-a4cc-32433d9800b3"
 
 [compat]
-oneAPI_Support_Headers_jll = "=2024.0.0"
+oneAPI_Support_Headers_jll = "=2024.1.0"

--- a/deps/build_local.jl
+++ b/deps/build_local.jl
@@ -40,7 +40,7 @@ if !isfile(joinpath(conda_dir, "condarc-julia.yml"))
     mkpath(joinpath(conda_dir, "conda-meta"))
     touch(joinpath(conda_dir, "conda-meta", "history"))
 end
-Conda.add(["dpcpp_linux-64=2024.0.0", "mkl-devel-dpcpp=2024.0.0"], conda_dir;
+Conda.add(["dpcpp_linux-64=2024.1.0", "mkl-devel-dpcpp=2024.1.0"], conda_dir;
           channel="intel")
 
 Conda.list(conda_dir)

--- a/deps/generate_helpers.jl
+++ b/deps/generate_helpers.jl
@@ -1,0 +1,97 @@
+non_parametric_routines = ["init_matrix_handle", "release_matrix_handle", "set_matrix_property",
+"init_matmat_descr", "release_matmat_descr", "set_matmat_data", "get_matmat_data", "matmat",
+"omatcopy", "sort_matrix", "optimize_gemv", "optimize_trmv", "optimize_trsv", "optimize_trsm"]
+
+function analyzer_template(library::String, cpp_headers::String, name_routine::String)
+  list_parameters = Vector{String}[]
+  list_types = Vector{String}[]
+  list_versions = String[]
+  list_suffix = String[]
+
+  if (library == "blas") || (library == "sparse" && !(name_routine ∈ non_parametric_routines))
+    prefix = (library == "sparse") ? "SPARSE_" : "BUF_"
+
+    occursin("ONEMKL_DECLARE_$(prefix)$(uppercase(name_routine))(T)", cpp_headers) && (list_parameters = ["T"])
+    occursin("ONEMKL_DECLARE_$(prefix)$(uppercase(name_routine))(FpType)", cpp_headers) && (list_parameters = ["FpType"])
+    occursin("ONEMKL_DECLARE_$(prefix)$(uppercase(name_routine))(Tf, Ti)", cpp_headers) && (list_parameters = ["Tf", "Ti"])
+    occursin("ONEMKL_DECLARE_$(prefix)$(uppercase(name_routine))(T, Ts)", cpp_headers) && (list_parameters = ["T", "Ts"])
+    occursin("ONEMKL_DECLARE_$(prefix)$(uppercase(name_routine))(IntType, FpType)", cpp_headers) && (list_parameters = ["IntType", "FpType"])
+    occursin("ONEMKL_DECLARE_$(prefix)$(uppercase(name_routine))(Ta, Tb, Tc, Ts)", cpp_headers) && (list_parameters = ["Ta", "Tb", "Tc", "Ts"])
+    occursin("ONEMKL_DECLARE_$(prefix)$(uppercase(name_routine))(T, Tres)", cpp_headers) && (list_parameters = ["T", "Tres"])
+    occursin("ONEMKL_DECLARE_$(prefix)$(uppercase(name_routine))(T, Treal)", cpp_headers) && (list_parameters = ["T", "Treal"])
+    occursin("ONEMKL_DECLARE_$(prefix)$(uppercase(name_routine))(T, Tc, Ts)", cpp_headers) && (list_parameters = ["T", "Tc", "Ts"])
+    occursin("ONEMKL_DECLARE_$(prefix)$(uppercase(name_routine))(T, Tc)", cpp_headers) && (list_parameters = ["T", "Tc"])
+    
+    (list_parameters == []) && @warn("Unable to determine the parametric parameters of $(name_routine).")
+    
+    for (type, version, suffix) in [(["sycl::half"], "H", ""),
+                                    (["float"], "S", ""),
+                                    (["double"], "D", ""),
+                                    (["std::complex<float>"], "C", ""),
+                                    (["std::complex<double>"], "Z", "")]
+      if occursin("ONEMKL_DECLARE_$(prefix)$(uppercase(name_routine))($(type[1]))", cpp_headers)
+        push!(list_types, type)
+        push!(list_versions, version)
+        push!(list_suffix, suffix)
+      end
+    end
+    
+    for (type, version, suffix) in [(["int32_t","float"], "S", ""),
+                                    (["int64_t","float"], "S", "_64"),
+                                    (["int32_t","double"], "D", ""),
+                                    (["int64_t","double"], "D", "_64"),
+                                    (["int32_t","std::complex<float>"], "C", ""),
+                                    (["int64_t","std::complex<float>"], "C", "_64"),
+                                    (["int32_t","std::complex<double>"], "Z", ""),
+                                    (["int64_t","std::complex<double>"], "Z", "_64"),
+                                    (["float","int32_t"], "S", ""),
+                                    (["float","int64_t"], "S", "_64"),
+                                    (["double","int32_t"], "D", ""),
+                                    (["double","int64_t"], "D", "_64"),
+                                    (["std::complex<float>","int32_t"], "C", ""),
+                                    (["std::complex<float>","int64_t"], "C", "_64"),
+                                    (["std::complex<double>","int32_t"], "Z", ""),
+                                    (["std::complex<double>","int64_t"], "Z", "_64"),
+                                    (["sycl::half","sycl::half"], "H", ""),
+                                    (["float","float"], "S", ""),
+                                    (["double","double"], "D", ""),
+                                    (["std::complex<float>","float"], "CS", ""),
+                                    (["std::complex<double>","double"], "ZD", ""),
+                                    (["std::complex<float>","std::complex<float>"], "C", ""),
+                                    (["std::complex<double>","std::complex<double>"], "Z", "")]
+      if occursin("ONEMKL_DECLARE_$(prefix)$(uppercase(name_routine))($(type[1]), $(type[2]))", cpp_headers)
+        push!(list_types, type)
+        push!(list_versions, version)
+        push!(list_suffix, suffix)
+      end
+    end
+    
+    for (type, version, suffix) in [(["sycl::half","sycl::half","sycl::half"], "H", ""),
+                                    (["float","float","float"], "S", ""),
+                                    (["double","double","double"], "D", ""),
+                                    (["std::complex<float>","float","float"], "CS", ""),
+                                    (["std::complex<float>","float", "std::complex<float>"], "C", ""),
+                                    (["std::complex<double>","double","double"], "ZD", ""),
+                                    (["std::complex<double>","double","std::complex<double>"], "Z", "")]
+      if occursin("ONEMKL_DECLARE_$(prefix)$(uppercase(name_routine))($(type[1]), $(type[2]), $(type[3]))", cpp_headers)
+        push!(list_types, type)
+        push!(list_versions, version)
+        push!(list_suffix, suffix)
+      end
+    end
+    
+    for (type, version, suffix) in [(["sycl::half","sycl::half","sycl::half","sycl::half"], "H", ""),
+                                    (["float","float","float","float"], "S", ""),
+                                    (["double","double","double","double"], "D", ""),
+                                    (["std::complex<float>","std::complex<float>","std::complex<float>","std::complex<float>"], "C", ""),
+                                    (["std::complex<double>","std::complex<double>","std::complex<double>","std::complex<double>"], "Z", "")]
+      if occursin("ONEMKL_DECLARE_$(prefix)$(uppercase(name_routine))($(type[1]), $(type[2]), $(type[3]), $(type[4]))", cpp_headers)
+        push!(list_types, type)
+        push!(list_versions, version)
+        push!(list_suffix, suffix)
+      end
+    end
+  end
+
+  return list_parameters, list_types, list_versions, list_suffix
+end

--- a/deps/onemkl_epilogue.h
+++ b/deps/onemkl_epilogue.h
@@ -1,3 +1,8 @@
+int onemklXsparse_matmat(syclQueue_t device_queue, matrix_handle_t A, matrix_handle_t B,
+                         matrix_handle_t C, onemklMatmatRequest req, matmat_descr_t
+                         descr, int64_t *sizeTempBuffer, void *tempBuffer);
+
+void mkl_sycl_destructor(void);
 int onemklDestroy(void);
 #ifdef __cplusplus
 }

--- a/deps/onemkl_prologue.cpp
+++ b/deps/onemkl_prologue.cpp
@@ -378,12 +378,12 @@ class trsmBatchInfo {
         }
 };
 
-extern "C" int onemklHgemmBatched(syclQueue_t device_queue, onemklTranspose transa,
-                                  onemklTranspose transb, int64_t *m,
-                                  int64_t *n, int64_t *k, uint16_t *alpha,
-                                  const short **a, int64_t *lda, const short **b,
-                                  int64_t *ldb, uint16_t *beta, short **c,
-                                  int64_t *ldc, int64_t group_count, int64_t *group_size) {
+extern "C" int onemklHgemm_batch(syclQueue_t device_queue, onemklTranspose transa,
+                                 onemklTranspose transb, int64_t *m,
+                                 int64_t *n, int64_t *k, uint16_t *alpha,
+                                 const short **a, int64_t *lda, const short **b,
+                                 int64_t *ldb, uint16_t *beta, short **c,
+                                 int64_t *ldc, int64_t group_count, int64_t *group_size) {
     gemmBatchInfo gemmInfo(device_queue, group_count, transa, transb);
     auto status = oneapi::mkl::blas::column_major::gemm_batch(device_queue->val,
                         &gemmInfo.m_transa[0], &gemmInfo.m_transb[0],
@@ -396,12 +396,12 @@ extern "C" int onemklHgemmBatched(syclQueue_t device_queue, onemklTranspose tran
     return 0;
 }
 
-extern "C" int onemklSgemmBatched(syclQueue_t device_queue, onemklTranspose transa,
-                                  onemklTranspose transb, int64_t *m,
-                                  int64_t *n, int64_t *k, float *alpha,
-                                  const float **a, int64_t *lda, const float **b,
-                                  int64_t *ldb, float *beta, float **c,
-                                  int64_t *ldc, int64_t group_count, int64_t *group_size) {
+extern "C" int onemklSgemm_batch(syclQueue_t device_queue, onemklTranspose transa,
+                                 onemklTranspose transb, int64_t *m,
+                                 int64_t *n, int64_t *k, float *alpha,
+                                 const float **a, int64_t *lda, const float **b,
+                                 int64_t *ldb, float *beta, float **c,
+                                 int64_t *ldc, int64_t group_count, int64_t *group_size) {
     gemmBatchInfo gemmInfo(device_queue, group_count, transa, transb);
     auto status = oneapi::mkl::blas::column_major::gemm_batch(device_queue->val,
                         &gemmInfo.m_transa[0], &gemmInfo.m_transb[0],
@@ -414,12 +414,12 @@ extern "C" int onemklSgemmBatched(syclQueue_t device_queue, onemklTranspose tran
     return 0;
 }
 
-extern "C" int onemklDgemmBatched(syclQueue_t device_queue, onemklTranspose transa,
-                                  onemklTranspose transb, int64_t *m,
-                                  int64_t *n, int64_t *k, double *alpha,
-                                  const double **a, int64_t *lda, const double **b,
-                                  int64_t *ldb, double *beta, double **c,
-                                  int64_t *ldc, int64_t group_count, int64_t *group_size) {
+extern "C" int onemklDgemm_batch(syclQueue_t device_queue, onemklTranspose transa,
+                                 onemklTranspose transb, int64_t *m,
+                                 int64_t *n, int64_t *k, double *alpha,
+                                 const double **a, int64_t *lda, const double **b,
+                                 int64_t *ldb, double *beta, double **c,
+                                 int64_t *ldc, int64_t group_count, int64_t *group_size) {
     gemmBatchInfo gemmInfo(device_queue, group_count, transa, transb);
     auto status = oneapi::mkl::blas::column_major::gemm_batch(device_queue->val,
                         &gemmInfo.m_transa[0], &gemmInfo.m_transb[0],
@@ -432,13 +432,13 @@ extern "C" int onemklDgemmBatched(syclQueue_t device_queue, onemklTranspose tran
     return 0;
 }
 
-extern "C" int onemklCgemmBatched(syclQueue_t device_queue, onemklTranspose transa,
-                                  onemklTranspose transb, int64_t *m,
-                                  int64_t *n, int64_t *k, float _Complex *alpha,
-                                  const float _Complex **a, int64_t *lda,
-                                  const float _Complex **b,
-                                  int64_t *ldb, float _Complex *beta, float _Complex **c,
-                                  int64_t *ldc, int64_t group_count, int64_t *group_size) {
+extern "C" int onemklCgemm_batch(syclQueue_t device_queue, onemklTranspose transa,
+                                 onemklTranspose transb, int64_t *m,
+                                 int64_t *n, int64_t *k, float _Complex *alpha,
+                                 const float _Complex **a, int64_t *lda,
+                                 const float _Complex **b,
+                                 int64_t *ldb, float _Complex *beta, float _Complex **c,
+                                 int64_t *ldc, int64_t group_count, int64_t *group_size) {
     gemmBatchInfo gemmInfo(device_queue, group_count, transa, transb);
     auto status = oneapi::mkl::blas::column_major::gemm_batch(device_queue->val,
                         &gemmInfo.m_transa[0], &gemmInfo.m_transb[0],
@@ -454,14 +454,14 @@ extern "C" int onemklCgemmBatched(syclQueue_t device_queue, onemklTranspose tran
     return 0;
 }
 
-extern "C" int onemklZgemmBatched(syclQueue_t device_queue, onemklTranspose transa,
-                                  onemklTranspose transb, int64_t *m,
-                                  int64_t *n, int64_t *k, double _Complex *alpha,
-                                  const double _Complex **a, int64_t *lda,
-                                  const double _Complex **b,
-                                  int64_t *ldb, double _Complex *beta,
-                                  double _Complex **c,
-                                  int64_t *ldc, int64_t group_count, int64_t *group_size) {
+extern "C" int onemklZgemm_batch(syclQueue_t device_queue, onemklTranspose transa,
+                                 onemklTranspose transb, int64_t *m,
+                                 int64_t *n, int64_t *k, double _Complex *alpha,
+                                 const double _Complex **a, int64_t *lda,
+                                 const double _Complex **b,
+                                 int64_t *ldb, double _Complex *beta,
+                                 double _Complex **c,
+                                 int64_t *ldc, int64_t group_count, int64_t *group_size) {
     gemmBatchInfo gemmInfo(device_queue, group_count, transa, transb);
     auto status = oneapi::mkl::blas::column_major::gemm_batch(device_queue->val,
                         &gemmInfo.m_transa[0], &gemmInfo.m_transb[0],
@@ -477,11 +477,11 @@ extern "C" int onemklZgemmBatched(syclQueue_t device_queue, onemklTranspose tran
     return 0;
 }
 
-extern "C" int onemklStrsmBatched(syclQueue_t device_queue, onemklSide left_right,
-                            onemklUplo upper_lower, onemklTranspose transa,
-                            onemklDiag unit_diag, int64_t *m, int64_t *n, float *alpha,
-                            const float **a, int64_t *lda, float **b, int64_t *ldb,
-                            int64_t group_count, int64_t *group_size) {
+extern "C" int onemklStrsm_batch(syclQueue_t device_queue, onemklSide left_right,
+                                 onemklUplo upper_lower, onemklTranspose transa,
+                                 onemklDiag unit_diag, int64_t *m, int64_t *n, float *alpha,
+                                 const float **a, int64_t *lda, float **b, int64_t *ldb,
+                                 int64_t group_count, int64_t *group_size) {
     trsmBatchInfo trsmInfo(device_queue, left_right, upper_lower, transa,
                            unit_diag, group_count);
 
@@ -494,12 +494,12 @@ extern "C" int onemklStrsmBatched(syclQueue_t device_queue, onemklSide left_righ
     return 0;
 }
 
-extern "C" int onemklDtrsmBatched(syclQueue_t device_queue, onemklSide left_right,
-                            onemklUplo upper_lower, onemklTranspose transa,
-                            onemklDiag unit_diag, int64_t *m, int64_t *n,
-                            double *alpha, const double **a, int64_t *lda,
-                            double **b, int64_t *ldb, int64_t group_count,
-                            int64_t *group_size) {
+extern "C" int onemklDtrsm_batch(syclQueue_t device_queue, onemklSide left_right,
+                                 onemklUplo upper_lower, onemklTranspose transa,
+                                 onemklDiag unit_diag, int64_t *m, int64_t *n,
+                                 double *alpha, const double **a, int64_t *lda,
+                                 double **b, int64_t *ldb, int64_t group_count,
+                                 int64_t *group_size) {
     trsmBatchInfo trsmInfo(device_queue, left_right, upper_lower, transa,
                                 unit_diag, group_count);
 
@@ -512,12 +512,12 @@ extern "C" int onemklDtrsmBatched(syclQueue_t device_queue, onemklSide left_righ
     return 0;
 }
 
-extern "C" int onemklCtrsmBatched(syclQueue_t device_queue, onemklSide left_right,
-                            onemklUplo upper_lower, onemklTranspose transa,
-                            onemklDiag unit_diag, int64_t *m, int64_t *n,
-                            float _Complex *alpha, const float _Complex **a,
-                            int64_t *lda, float _Complex **b, int64_t *ldb,
-                            int64_t group_count, int64_t *group_size) {
+extern "C" int onemklCtrsm_batch(syclQueue_t device_queue, onemklSide left_right,
+                                 onemklUplo upper_lower, onemklTranspose transa,
+                                 onemklDiag unit_diag, int64_t *m, int64_t *n,
+                                 float _Complex *alpha, const float _Complex **a,
+                                 int64_t *lda, float _Complex **b, int64_t *ldb,
+                                 int64_t group_count, int64_t *group_size) {
     trsmBatchInfo trsmInfo(device_queue, left_right, upper_lower, transa,
                                 unit_diag, group_count);
 
@@ -532,12 +532,12 @@ extern "C" int onemklCtrsmBatched(syclQueue_t device_queue, onemklSide left_righ
     return 0;
 }
 
-extern "C" int onemklZtrsmBatched(syclQueue_t device_queue, onemklSide left_right,
-                            onemklUplo upper_lower, onemklTranspose transa,
-                            onemklDiag unit_diag, int64_t *m, int64_t *n,
-                            double _Complex *alpha, const double _Complex **a,
-                            int64_t *lda, double _Complex **b, int64_t *ldb,
-                            int64_t group_count, int64_t *group_size) {
+extern "C" int onemklZtrsm_batch(syclQueue_t device_queue, onemklSide left_right,
+                                 onemklUplo upper_lower, onemklTranspose transa,
+                                 onemklDiag unit_diag, int64_t *m, int64_t *n,
+                                 double _Complex *alpha, const double _Complex **a,
+                                 int64_t *lda, double _Complex **b, int64_t *ldb,
+                                 int64_t group_count, int64_t *group_size) {
     trsmBatchInfo trsmInfo(device_queue, left_right,
                                 upper_lower, transa, unit_diag, group_count);
 
@@ -548,135 +548,6 @@ extern "C" int onemklZtrsmBatched(syclQueue_t device_queue, onemklSide left_righ
                         reinterpret_cast<const std::complex<double> **>(&a[0]),
                         lda, reinterpret_cast<std::complex<double> **>(&b[0]),
                         ldb, group_count, group_size, {});
-    __FORCE_MKL_FLUSH__(status);
-    return 0;
-}
-
-extern "C" int onemklHgemmBatchStrided(syclQueue_t device_queue, onemklTranspose transa,
-                        onemklTranspose transb, int64_t m, int64_t n, int64_t k,
-                        uint16_t *alpha, const short *a, int64_t lda, int64_t stridea,
-                        const short *b, int64_t ldb, int64_t strideb, uint16_t *beta,
-                        short *c, int64_t ldc, int64_t stridec, int64_t batch_size) {
-    auto status = oneapi::mkl::blas::column_major::gemm_batch(device_queue->val, convert(transa),
-                                                    convert(transb), m, n, k,
-                                                    *reinterpret_cast<const sycl::half *>(alpha),
-                                                    reinterpret_cast<const sycl::half *>(a), lda, stridea,
-                                                    reinterpret_cast<const sycl::half *>(b), ldb, strideb,
-                                                    *reinterpret_cast<const sycl::half *>(beta),
-                                                    reinterpret_cast<sycl::half *>(c), ldc, stridec, batch_size, {});
-    __FORCE_MKL_FLUSH__(status);
-    return 0;
-}
-
-extern "C" int onemklSgemmBatchStrided(syclQueue_t device_queue, onemklTranspose transa,
-                        onemklTranspose transb, int64_t m, int64_t n, int64_t k,
-                        float *alpha, const float *a, int64_t lda, int64_t stridea,
-                        const float *b, int64_t ldb, int64_t strideb, float *beta,
-                        float *c, int64_t ldc, int64_t stridec, int64_t batch_size) {
-    auto status = oneapi::mkl::blas::column_major::gemm_batch(device_queue->val, convert(transa),
-                                                    convert(transb), m, n, k, *alpha, a, lda, stridea,
-                                                    b, ldb, strideb, *beta, c, ldc, stridec, batch_size, {});
-    __FORCE_MKL_FLUSH__(status);
-    return 0;
-}
-
-extern "C" int onemklDgemmBatchStrided(syclQueue_t device_queue, onemklTranspose transa,
-                        onemklTranspose transb, int64_t m, int64_t n, int64_t k,
-                        double *alpha, const double *a, int64_t lda, int64_t stridea,
-                        const double *b, int64_t ldb, int64_t strideb, double *beta,
-                        double *c, int64_t ldc, int64_t stridec, int64_t batch_size) {
-    auto status = oneapi::mkl::blas::column_major::gemm_batch(device_queue->val, convert(transa),
-                                                    convert(transb), m, n, k, *alpha, a, lda, stridea,
-                                                    b, ldb, strideb, *beta, c, ldc, stridec, batch_size, {});
-    __FORCE_MKL_FLUSH__(status);
-    return 0;
-}
-
-extern "C" int onemklCgemmBatchStrided(syclQueue_t device_queue, onemklTranspose transa,
-                        onemklTranspose transb, int64_t m, int64_t n, int64_t k,
-                        float _Complex *alpha, const float _Complex *a, int64_t lda, int64_t stridea,
-                        const float _Complex *b, int64_t ldb, int64_t strideb, float _Complex *beta,
-                        float _Complex *c, int64_t ldc, int64_t stridec, int64_t batch_size) {
-    auto status = oneapi::mkl::blas::column_major::gemm_batch(device_queue->val, convert(transa),
-                                                    convert(transb), m, n, k, *alpha,
-                                                    reinterpret_cast<const std::complex<float> *>(a),
-                                                    lda, stridea,
-                                                    reinterpret_cast<const std::complex<float> *>(b),
-                                                    ldb, strideb, *beta,
-                                                    reinterpret_cast<std::complex<float> *>(c),
-                                                    ldc, stridec, batch_size, {});
-    __FORCE_MKL_FLUSH__(status);
-    return 0;
-}
-
-extern "C" int onemklZgemmBatchStrided(syclQueue_t device_queue, onemklTranspose transa,
-                        onemklTranspose transb, int64_t m, int64_t n, int64_t k,
-                        double _Complex *alpha, const double _Complex *a, int64_t lda, int64_t stridea,
-                        const double _Complex *b, int64_t ldb, int64_t strideb, double _Complex *beta,
-                        double _Complex *c, int64_t ldc, int64_t stridec, int64_t batch_size) {
-    auto status = oneapi::mkl::blas::column_major::gemm_batch(device_queue->val, convert(transa),
-                                                    convert(transb), m, n, k, *alpha,
-                                                    reinterpret_cast<const std::complex<double> *>(a),
-                                                    lda, stridea,
-                                                    reinterpret_cast<const std::complex<double> *>(b),
-                                                    ldb, strideb, *beta,
-                                                    reinterpret_cast<std::complex<double> *>(c),
-                                                    ldc, stridec, batch_size, {});
-    __FORCE_MKL_FLUSH__(status);
-    return 0;
-}
-
-extern "C" int onemklHgemm(syclQueue_t device_queue, onemklTranspose transA,
-                           onemklTranspose transB, int64_t m, int64_t n,
-                           int64_t k, uint16_t *alpha, const short *A, int64_t lda,
-                           const short *B, int64_t ldb, uint16_t *beta, short *C,
-                           int64_t ldc) {
-    auto status = oneapi::mkl::blas::column_major::gemm(device_queue->val, convert(transA),
-                                          convert(transB), m, n, k,
-                                          *reinterpret_cast<const sycl::half *>(alpha),
-                                          reinterpret_cast<const sycl::half *>(A), lda,
-                                          reinterpret_cast<const sycl::half *>(B), ldb,
-                                          *reinterpret_cast<const sycl::half *>(beta),
-                                          reinterpret_cast<sycl::half *>(C), ldc, {});
-    __FORCE_MKL_FLUSH__(status);
-    return 0;
-}
-
-extern "C" int onemklHdot(syclQueue_t device_queue, int64_t n,
-                           const short *x, int64_t incx, const short *y,
-                           int64_t incy, short *result) {
-    auto status = oneapi::mkl::blas::column_major::dot(device_queue->val, n,
-                                        reinterpret_cast<const sycl::half *>(x),
-                                        incx, reinterpret_cast<const sycl::half *>(y),
-                                        incy, reinterpret_cast<sycl::half *>(result), {});
-    __FORCE_MKL_FLUSH__(status);
-    return 0;
-}
-
-extern "C" int onemklHaxpy(syclQueue_t device_queue, int64_t n, uint16_t *alpha,
-                            const short *x, std::int64_t incx, short *y, int64_t incy) {
-    auto status = oneapi::mkl::blas::column_major::axpy(device_queue->val, n,
-                                        *reinterpret_cast<const sycl::half *>(alpha),
-                                        reinterpret_cast<const sycl::half *>(x),
-                                        incx, reinterpret_cast<sycl::half *>(y), incy, {});
-    __FORCE_MKL_FLUSH__(status);
-    return 0;
-}
-
-extern "C" int onemklHscal(syclQueue_t device_queue, int64_t n, uint16_t *alpha,
-                            short *x, int64_t incx) {
-    auto status = oneapi::mkl::blas::column_major::scal(device_queue->val, n,
-                                                        *reinterpret_cast<const sycl::half *>(alpha),
-                                                        reinterpret_cast<sycl::half *>(x), incx, {});
-    __FORCE_MKL_FLUSH__(status);
-    return 0;
-}
-
-extern "C" int onemklHnrm2(syclQueue_t device_queue, int64_t n, const short *x,
-                            int64_t incx, short *result) {
-    auto status = oneapi::mkl::blas::column_major::nrm2(device_queue->val, n,
-                        reinterpret_cast<const sycl::half *>(x), incx,
-                        reinterpret_cast<sycl::half *>(result), {});
     __FORCE_MKL_FLUSH__(status);
     return 0;
 }

--- a/deps/onemkl_prologue.h
+++ b/deps/onemkl_prologue.h
@@ -126,119 +126,69 @@ typedef struct matrix_handle *matrix_handle_t;
 struct matmat_descr;
 typedef struct matmat_descr *matmat_descr_t;
 
-int onemklHgemmBatched(syclQueue_t device_queue, onemklTranspose transa,
-                       onemklTranspose transb, int64_t *m,
-                       int64_t *n, int64_t *k, uint16_t *alpha,
-                       const short **a, int64_t *lda, const short **b,
-                       int64_t *ldb, uint16_t *beta, short **c,
-                       int64_t *ldc, int64_t group_count, int64_t *group_size);
+int onemklHgemm_batch(syclQueue_t device_queue, onemklTranspose transa,
+                      onemklTranspose transb, int64_t *m,
+                      int64_t *n, int64_t *k, uint16_t *alpha,
+                      const short **a, int64_t *lda, const short **b,
+                      int64_t *ldb, uint16_t *beta, short **c,
+                      int64_t *ldc, int64_t group_count, int64_t *group_size);
 
-int onemklSgemmBatched(syclQueue_t device_queue, onemklTranspose transa,
-                       onemklTranspose transb, int64_t *m,
-                       int64_t *n, int64_t *k, float *alpha,
-                       const float **a, int64_t *lda, const float **b,
-                       int64_t *ldb, float *beta, float **c,
-                       int64_t *ldc, int64_t group_count, int64_t *group_size);
+int onemklSgemm_batch(syclQueue_t device_queue, onemklTranspose transa,
+                      onemklTranspose transb, int64_t *m,
+                      int64_t *n, int64_t *k, float *alpha,
+                      const float **a, int64_t *lda, const float **b,
+                      int64_t *ldb, float *beta, float **c,
+                      int64_t *ldc, int64_t group_count, int64_t *group_size);
 
-int onemklDgemmBatched(syclQueue_t device_queue, onemklTranspose transa,
-                       onemklTranspose transb, int64_t *m,
-                       int64_t *n, int64_t *k, double *alpha,
-                       const double **a, int64_t *lda, const double **b,
-                       int64_t *ldb, double *beta, double **c,
-                       int64_t *ldc, int64_t group_count, int64_t *group_size);
+int onemklDgemm_batch(syclQueue_t device_queue, onemklTranspose transa,
+                      onemklTranspose transb, int64_t *m,
+                      int64_t *n, int64_t *k, double *alpha,
+                      const double **a, int64_t *lda, const double **b,
+                      int64_t *ldb, double *beta, double **c,
+                      int64_t *ldc, int64_t group_count, int64_t *group_size);
 
-int onemklCgemmBatched(syclQueue_t device_queue, onemklTranspose transa,
-                       onemklTranspose transb, int64_t *m,
-                       int64_t *n, int64_t *k, float _Complex *alpha,
-                       const float _Complex **a, int64_t *lda,
-                       const float _Complex **b,
-                       int64_t *ldb, float _Complex *beta,
-                       float _Complex **c, int64_t *ldc,
-                       int64_t group_count, int64_t *group_size);
+int onemklCgemm_batch(syclQueue_t device_queue, onemklTranspose transa,
+                      onemklTranspose transb, int64_t *m,
+                      int64_t *n, int64_t *k, float _Complex *alpha,
+                      const float _Complex **a, int64_t *lda,
+                      const float _Complex **b,
+                      int64_t *ldb, float _Complex *beta,
+                      float _Complex **c, int64_t *ldc,
+                      int64_t group_count, int64_t *group_size);
 
-int onemklZgemmBatched(syclQueue_t device_queue, onemklTranspose transa,
-                       onemklTranspose transb, int64_t *m,
-                       int64_t *n, int64_t *k, double _Complex *alpha,
-                       const double _Complex **a, int64_t *lda,
-                       const double _Complex **b,
-                       int64_t *ldb, double _Complex *beta,
-                       double _Complex **c, int64_t *ldc,
-                       int64_t group_count, int64_t *group_size);
+int onemklZgemm_batch(syclQueue_t device_queue, onemklTranspose transa,
+                      onemklTranspose transb, int64_t *m,
+                      int64_t *n, int64_t *k, double _Complex *alpha,
+                      const double _Complex **a, int64_t *lda,
+                      const double _Complex **b,
+                      int64_t *ldb, double _Complex *beta,
+                      double _Complex **c, int64_t *ldc,
+                      int64_t group_count, int64_t *group_size);
 
-int onemklStrsmBatched(syclQueue_t device_queue, onemklSide left_right,
-                       onemklUplo upper_lower, onemklTranspose transa,
-                       onemklDiag unit_diag, int64_t *m, int64_t *n,
-                       float *alpha, const float **a, int64_t *lda,
-                       float **b, int64_t *ldb, int64_t group_count,
-                       int64_t *group_size);
+int onemklStrsm_batch(syclQueue_t device_queue, onemklSide left_right,
+                      onemklUplo upper_lower, onemklTranspose transa,
+                      onemklDiag unit_diag, int64_t *m, int64_t *n,
+                      float *alpha, const float **a, int64_t *lda,
+                      float **b, int64_t *ldb, int64_t group_count,
+                      int64_t *group_size);
 
-int onemklDtrsmBatched(syclQueue_t device_queue, onemklSide left_right,
-                       onemklUplo upper_lower, onemklTranspose transa,
-                       onemklDiag unit_diag, int64_t *m, int64_t *n,
-                       double *alpha, const double **a, int64_t *lda,
-                       double **b, int64_t *ldb, int64_t group_count,
-                       int64_t *group_size);
+int onemklDtrsm_batch(syclQueue_t device_queue, onemklSide left_right,
+                      onemklUplo upper_lower, onemklTranspose transa,
+                      onemklDiag unit_diag, int64_t *m, int64_t *n,
+                      double *alpha, const double **a, int64_t *lda,
+                      double **b, int64_t *ldb, int64_t group_count,
+                      int64_t *group_size);
 
-int onemklCtrsmBatched(syclQueue_t device_queue, onemklSide left_right,
-                       onemklUplo upper_lower, onemklTranspose transa,
-                       onemklDiag unit_diag, int64_t *m, int64_t *n,
-                       float _Complex *alpha, const float _Complex **a, int64_t *lda,
-                       float _Complex **b, int64_t *ldb, int64_t group_count,
-                       int64_t *group_size);
+int onemklCtrsm_batch(syclQueue_t device_queue, onemklSide left_right,
+                      onemklUplo upper_lower, onemklTranspose transa,
+                      onemklDiag unit_diag, int64_t *m, int64_t *n,
+                      float _Complex *alpha, const float _Complex **a, int64_t *lda,
+                      float _Complex **b, int64_t *ldb, int64_t group_count,
+                      int64_t *group_size);
 
-int onemklZtrsmBatched(syclQueue_t device_queue, onemklSide left_right,
-                       onemklUplo upper_lower, onemklTranspose transa,
-                       onemklDiag unit_diag, int64_t *m, int64_t *n,
-                       double _Complex *alpha, const double _Complex **a, int64_t *lda,
-                       double _Complex **b, int64_t *ldb, int64_t group_count,
-                       int64_t *group_size);
-
-int onemklHgemmBatchStrided(syclQueue_t device_queue, onemklTranspose transa,
-                            onemklTranspose transb, int64_t m, int64_t n, int64_t k,
-                            uint16_t *alpha, const short *a, int64_t lda, int64_t stridea,
-                            const short *b, int64_t ldb, int64_t strideb, uint16_t *beta,
-                            short *c, int64_t ldc, int64_t stridec, int64_t batch_size);
-
-int onemklSgemmBatchStrided(syclQueue_t device_queue, onemklTranspose transa,
-                            onemklTranspose transb, int64_t m, int64_t n, int64_t k,
-                            float *alpha, const float *a, int64_t lda, int64_t stridea,
-                            const float *b, int64_t ldb, int64_t strideb, float *beta,
-                            float *c, int64_t ldc, int64_t stridec, int64_t batch_size);
-
-int onemklDgemmBatchStrided(syclQueue_t device_queue, onemklTranspose transa,
-                            onemklTranspose transb, int64_t m, int64_t n, int64_t k,
-                            double *alpha, const double *a, int64_t lda, int64_t stridea,
-                            const double *b, int64_t ldb, int64_t strideb, double *beta,
-                            double *c, int64_t ldc, int64_t stridec, int64_t batch_size);
-
-int onemklCgemmBatchStrided(syclQueue_t device_queue, onemklTranspose transa,
-                            onemklTranspose transb, int64_t m, int64_t n, int64_t k,
-                            float _Complex *alpha, const float _Complex *a, int64_t lda,
-                            int64_t stridea, const float _Complex *b, int64_t ldb,
-                            int64_t strideb, float _Complex *beta, float _Complex *c,
-                            int64_t ldc, int64_t stridec, int64_t batch_size);
-
-int onemklZgemmBatchStrided(syclQueue_t device_queue, onemklTranspose transa,
-                            onemklTranspose transb, int64_t m, int64_t n, int64_t k,
-                            double _Complex *alpha, const double _Complex *a, int64_t lda,
-                            int64_t stridea, const double _Complex *b, int64_t ldb,
-                            int64_t strideb, double _Complex *beta, double _Complex *c,
-                            int64_t ldc, int64_t stridec, int64_t batch_size);
-
-int onemklHgemm(syclQueue_t device_queue, onemklTranspose transA,
-                onemklTranspose transB, int64_t m, int64_t n,
-                int64_t k, uint16_t *alpha, const short *A, int64_t lda,
-                const short *B, int64_t ldb, uint16_t *beta, short *C,
-                int64_t ldc);
-
-int onemklHaxpy(syclQueue_t device_queue, int64_t n, uint16_t *alpha, const short *x,
-                int64_t incx, short *y, int64_t incy);
-
-int onemklHscal(syclQueue_t device_queue, int64_t n, uint16_t *alpha,
-                short *x, int64_t incx);
-
-int onemklHnrm2(syclQueue_t device_queue, int64_t n, const short *x,
-                int64_t incx, short *result);
-
-int onemklHdot(syclQueue_t device_queue, int64_t n, const short *x,
-               int64_t incx, const short *y, int64_t incy, short *result);
+int onemklZtrsm_batch(syclQueue_t device_queue, onemklSide left_right,
+                      onemklUplo upper_lower, onemklTranspose transa,
+                      onemklDiag unit_diag, int64_t *m, int64_t *n,
+                      double _Complex *alpha, const double _Complex **a, int64_t *lda,
+                      double _Complex **b, int64_t *ldb, int64_t group_count,
+                      int64_t *group_size);

--- a/deps/src/onemkl.cpp
+++ b/deps/src/onemkl.cpp
@@ -1218,49 +1218,97 @@ extern "C" int onemklZdotu(syclQueue_t device_queue, int64_t n, double _Complex 
    return 0;
 }
 
-extern "C" int onemklSiamax(syclQueue_t device_queue, int64_t n, float *x, int64_t incx, int64_t *result, onemklIndex base) {
+extern "C" int onemklSiamax(syclQueue_t device_queue, int64_t n, float *x, int64_t incx, int32_t *result, onemklIndex base) {
    auto status = oneapi::mkl::blas::column_major::iamax(device_queue->val, n, x, incx, result, convert(base), {});
    __FORCE_MKL_FLUSH__(status);
    return 0;
 }
 
-extern "C" int onemklDiamax(syclQueue_t device_queue, int64_t n, double *x, int64_t incx, int64_t *result, onemklIndex base) {
+extern "C" int onemklSiamax_64(syclQueue_t device_queue, int64_t n, float *x, int64_t incx, int64_t *result, onemklIndex base) {
    auto status = oneapi::mkl::blas::column_major::iamax(device_queue->val, n, x, incx, result, convert(base), {});
    __FORCE_MKL_FLUSH__(status);
    return 0;
 }
 
-extern "C" int onemklCiamax(syclQueue_t device_queue, int64_t n, float _Complex *x, int64_t incx, int64_t *result, onemklIndex base) {
+extern "C" int onemklDiamax(syclQueue_t device_queue, int64_t n, double *x, int64_t incx, int32_t *result, onemklIndex base) {
+   auto status = oneapi::mkl::blas::column_major::iamax(device_queue->val, n, x, incx, result, convert(base), {});
+   __FORCE_MKL_FLUSH__(status);
+   return 0;
+}
+
+extern "C" int onemklDiamax_64(syclQueue_t device_queue, int64_t n, double *x, int64_t incx, int64_t *result, onemklIndex base) {
+   auto status = oneapi::mkl::blas::column_major::iamax(device_queue->val, n, x, incx, result, convert(base), {});
+   __FORCE_MKL_FLUSH__(status);
+   return 0;
+}
+
+extern "C" int onemklCiamax(syclQueue_t device_queue, int64_t n, float _Complex *x, int64_t incx, int32_t *result, onemklIndex base) {
    auto status = oneapi::mkl::blas::column_major::iamax(device_queue->val, n, reinterpret_cast<std::complex<float>*>(x), incx, result, convert(base), {});
    __FORCE_MKL_FLUSH__(status);
    return 0;
 }
 
-extern "C" int onemklZiamax(syclQueue_t device_queue, int64_t n, double _Complex *x, int64_t incx, int64_t *result, onemklIndex base) {
+extern "C" int onemklCiamax_64(syclQueue_t device_queue, int64_t n, float _Complex *x, int64_t incx, int64_t *result, onemklIndex base) {
+   auto status = oneapi::mkl::blas::column_major::iamax(device_queue->val, n, reinterpret_cast<std::complex<float>*>(x), incx, result, convert(base), {});
+   __FORCE_MKL_FLUSH__(status);
+   return 0;
+}
+
+extern "C" int onemklZiamax(syclQueue_t device_queue, int64_t n, double _Complex *x, int64_t incx, int32_t *result, onemklIndex base) {
    auto status = oneapi::mkl::blas::column_major::iamax(device_queue->val, n, reinterpret_cast<std::complex<double>*>(x), incx, result, convert(base), {});
    __FORCE_MKL_FLUSH__(status);
    return 0;
 }
 
-extern "C" int onemklSiamin(syclQueue_t device_queue, int64_t n, float *x, int64_t incx, int64_t *result, onemklIndex base) {
+extern "C" int onemklZiamax_64(syclQueue_t device_queue, int64_t n, double _Complex *x, int64_t incx, int64_t *result, onemklIndex base) {
+   auto status = oneapi::mkl::blas::column_major::iamax(device_queue->val, n, reinterpret_cast<std::complex<double>*>(x), incx, result, convert(base), {});
+   __FORCE_MKL_FLUSH__(status);
+   return 0;
+}
+
+extern "C" int onemklSiamin(syclQueue_t device_queue, int64_t n, float *x, int64_t incx, int32_t *result, onemklIndex base) {
    auto status = oneapi::mkl::blas::column_major::iamin(device_queue->val, n, x, incx, result, convert(base), {});
    __FORCE_MKL_FLUSH__(status);
    return 0;
 }
 
-extern "C" int onemklDiamin(syclQueue_t device_queue, int64_t n, double *x, int64_t incx, int64_t *result, onemklIndex base) {
+extern "C" int onemklSiamin_64(syclQueue_t device_queue, int64_t n, float *x, int64_t incx, int64_t *result, onemklIndex base) {
    auto status = oneapi::mkl::blas::column_major::iamin(device_queue->val, n, x, incx, result, convert(base), {});
    __FORCE_MKL_FLUSH__(status);
    return 0;
 }
 
-extern "C" int onemklCiamin(syclQueue_t device_queue, int64_t n, float _Complex *x, int64_t incx, int64_t *result, onemklIndex base) {
+extern "C" int onemklDiamin(syclQueue_t device_queue, int64_t n, double *x, int64_t incx, int32_t *result, onemklIndex base) {
+   auto status = oneapi::mkl::blas::column_major::iamin(device_queue->val, n, x, incx, result, convert(base), {});
+   __FORCE_MKL_FLUSH__(status);
+   return 0;
+}
+
+extern "C" int onemklDiamin_64(syclQueue_t device_queue, int64_t n, double *x, int64_t incx, int64_t *result, onemklIndex base) {
+   auto status = oneapi::mkl::blas::column_major::iamin(device_queue->val, n, x, incx, result, convert(base), {});
+   __FORCE_MKL_FLUSH__(status);
+   return 0;
+}
+
+extern "C" int onemklCiamin(syclQueue_t device_queue, int64_t n, float _Complex *x, int64_t incx, int32_t *result, onemklIndex base) {
    auto status = oneapi::mkl::blas::column_major::iamin(device_queue->val, n, reinterpret_cast<std::complex<float>*>(x), incx, result, convert(base), {});
    __FORCE_MKL_FLUSH__(status);
    return 0;
 }
 
-extern "C" int onemklZiamin(syclQueue_t device_queue, int64_t n, double _Complex *x, int64_t incx, int64_t *result, onemklIndex base) {
+extern "C" int onemklCiamin_64(syclQueue_t device_queue, int64_t n, float _Complex *x, int64_t incx, int64_t *result, onemklIndex base) {
+   auto status = oneapi::mkl::blas::column_major::iamin(device_queue->val, n, reinterpret_cast<std::complex<float>*>(x), incx, result, convert(base), {});
+   __FORCE_MKL_FLUSH__(status);
+   return 0;
+}
+
+extern "C" int onemklZiamin(syclQueue_t device_queue, int64_t n, double _Complex *x, int64_t incx, int32_t *result, onemklIndex base) {
+   auto status = oneapi::mkl::blas::column_major::iamin(device_queue->val, n, reinterpret_cast<std::complex<double>*>(x), incx, result, convert(base), {});
+   __FORCE_MKL_FLUSH__(status);
+   return 0;
+}
+
+extern "C" int onemklZiamin_64(syclQueue_t device_queue, int64_t n, double _Complex *x, int64_t incx, int64_t *result, onemklIndex base) {
    auto status = oneapi::mkl::blas::column_major::iamin(device_queue->val, n, reinterpret_cast<std::complex<double>*>(x), incx, result, convert(base), {});
    __FORCE_MKL_FLUSH__(status);
    return 0;
@@ -2207,21 +2255,25 @@ extern "C" int64_t onemklZgeqrf_scratchpad_size(syclQueue_t device_queue, int64_
 
 extern "C" int onemklCgeqrf(syclQueue_t device_queue, int64_t m, int64_t n, float _Complex *a, int64_t lda, float _Complex *tau, float _Complex *scratchpad, int64_t scratchpad_size) {
    auto status = oneapi::mkl::lapack::geqrf(device_queue->val, m, n, reinterpret_cast<std::complex<float>*>(a), lda, reinterpret_cast<std::complex<float>*>(tau), reinterpret_cast<std::complex<float>*>(scratchpad), scratchpad_size, {});
+   __FORCE_MKL_FLUSH__(status);
    return 0;
 }
 
 extern "C" int onemklDgeqrf(syclQueue_t device_queue, int64_t m, int64_t n, double *a, int64_t lda, double *tau, double *scratchpad, int64_t scratchpad_size) {
    auto status = oneapi::mkl::lapack::geqrf(device_queue->val, m, n, a, lda, tau, scratchpad, scratchpad_size, {});
+   __FORCE_MKL_FLUSH__(status);
    return 0;
 }
 
 extern "C" int onemklSgeqrf(syclQueue_t device_queue, int64_t m, int64_t n, float *a, int64_t lda, float *tau, float *scratchpad, int64_t scratchpad_size) {
    auto status = oneapi::mkl::lapack::geqrf(device_queue->val, m, n, a, lda, tau, scratchpad, scratchpad_size, {});
+   __FORCE_MKL_FLUSH__(status);
    return 0;
 }
 
 extern "C" int onemklZgeqrf(syclQueue_t device_queue, int64_t m, int64_t n, double _Complex *a, int64_t lda, double _Complex *tau, double _Complex *scratchpad, int64_t scratchpad_size) {
    auto status = oneapi::mkl::lapack::geqrf(device_queue->val, m, n, reinterpret_cast<std::complex<double>*>(a), lda, reinterpret_cast<std::complex<double>*>(tau), reinterpret_cast<std::complex<double>*>(scratchpad), scratchpad_size, {});
+   __FORCE_MKL_FLUSH__(status);
    return 0;
 }
 
@@ -2265,6 +2317,50 @@ extern "C" int onemklDgesvd(syclQueue_t device_queue, onemklJobsvd jobu, onemklJ
 
 extern "C" int onemklSgesvd(syclQueue_t device_queue, onemklJobsvd jobu, onemklJobsvd jobvt, int64_t m, int64_t n, float *a, int64_t lda, float *s, float *u, int64_t ldu, float *vt, int64_t ldvt, float *scratchpad, int64_t scratchpad_size) {
    auto status = oneapi::mkl::lapack::gesvd(device_queue->val, convert(jobu), convert(jobvt), m, n, a, lda, s, u, ldu, vt, ldvt, scratchpad, scratchpad_size, {});
+   __FORCE_MKL_FLUSH__(status);
+   return 0;
+}
+
+extern "C" int64_t onemklSgesvda_batch_strided_scratchpad_size(syclQueue_t device_queue, int64_t m, int64_t n, int64_t lda, int64_t stride_a, int64_t stride_s, int64_t ldu, int64_t stride_u, int64_t ldvt, int64_t stride_vt, int64_t batch_size) {
+   int64_t scratchpad_size = oneapi::mkl::lapack::gesvda_batch_scratchpad_size<float>(device_queue->val, m, n, lda, stride_a, stride_s, ldu, stride_u, ldvt, stride_vt, batch_size);
+   return scratchpad_size;
+}
+
+extern "C" int64_t onemklDgesvda_batch_strided_scratchpad_size(syclQueue_t device_queue, int64_t m, int64_t n, int64_t lda, int64_t stride_a, int64_t stride_s, int64_t ldu, int64_t stride_u, int64_t ldvt, int64_t stride_vt, int64_t batch_size) {
+   int64_t scratchpad_size = oneapi::mkl::lapack::gesvda_batch_scratchpad_size<double>(device_queue->val, m, n, lda, stride_a, stride_s, ldu, stride_u, ldvt, stride_vt, batch_size);
+   return scratchpad_size;
+}
+
+extern "C" int64_t onemklCgesvda_batch_strided_scratchpad_size(syclQueue_t device_queue, int64_t m, int64_t n, int64_t lda, int64_t stride_a, int64_t stride_s, int64_t ldu, int64_t stride_u, int64_t ldvt, int64_t stride_vt, int64_t batch_size) {
+   int64_t scratchpad_size = oneapi::mkl::lapack::gesvda_batch_scratchpad_size<std::complex<float>>(device_queue->val, m, n, lda, stride_a, stride_s, ldu, stride_u, ldvt, stride_vt, batch_size);
+   return scratchpad_size;
+}
+
+extern "C" int64_t onemklZgesvda_batch_strided_scratchpad_size(syclQueue_t device_queue, int64_t m, int64_t n, int64_t lda, int64_t stride_a, int64_t stride_s, int64_t ldu, int64_t stride_u, int64_t ldvt, int64_t stride_vt, int64_t batch_size) {
+   int64_t scratchpad_size = oneapi::mkl::lapack::gesvda_batch_scratchpad_size<std::complex<double>>(device_queue->val, m, n, lda, stride_a, stride_s, ldu, stride_u, ldvt, stride_vt, batch_size);
+   return scratchpad_size;
+}
+
+extern "C" int onemklCgesvda_batch_strided(syclQueue_t device_queue, int64_t *iparm, int64_t *irank, int64_t m, int64_t n, float _Complex *a, int64_t lda, int64_t stride_a, float *s, int64_t stride_s, float _Complex *u, int64_t ldu, int64_t stride_u, float _Complex *vt, int64_t ldvt, int64_t stride_vt, float *tolerance, float *residual, int64_t batch_size, float _Complex *scratchpad, int64_t scratchpad_size) {
+   auto status = oneapi::mkl::lapack::gesvda_batch(device_queue->val, iparm, irank, m, n, reinterpret_cast<std::complex<float>*>(a), lda, stride_a, s, stride_s, reinterpret_cast<std::complex<float>*>(u), ldu, stride_u, reinterpret_cast<std::complex<float>*>(vt), ldvt, stride_vt, *tolerance, residual, batch_size, reinterpret_cast<std::complex<float>*>(scratchpad), scratchpad_size, {});
+   __FORCE_MKL_FLUSH__(status);
+   return 0;
+}
+
+extern "C" int onemklDgesvda_batch_strided(syclQueue_t device_queue, int64_t *iparm, int64_t *irank, int64_t m, int64_t n, double *a, int64_t lda, int64_t stride_a, double *s, int64_t stride_s, double *u, int64_t ldu, int64_t stride_u, double *vt, int64_t ldvt, int64_t stride_vt, double *tolerance, double *residual, int64_t batch_size, double *scratchpad, int64_t scratchpad_size) {
+   auto status = oneapi::mkl::lapack::gesvda_batch(device_queue->val, iparm, irank, m, n, a, lda, stride_a, s, stride_s, u, ldu, stride_u, vt, ldvt, stride_vt, *tolerance, residual, batch_size, scratchpad, scratchpad_size, {});
+   __FORCE_MKL_FLUSH__(status);
+   return 0;
+}
+
+extern "C" int onemklSgesvda_batch_strided(syclQueue_t device_queue, int64_t *iparm, int64_t *irank, int64_t m, int64_t n, float *a, int64_t lda, int64_t stride_a, float *s, int64_t stride_s, float *u, int64_t ldu, int64_t stride_u, float *vt, int64_t ldvt, int64_t stride_vt, float *tolerance, float *residual, int64_t batch_size, float *scratchpad, int64_t scratchpad_size) {
+   auto status = oneapi::mkl::lapack::gesvda_batch(device_queue->val, iparm, irank, m, n, a, lda, stride_a, s, stride_s, u, ldu, stride_u, vt, ldvt, stride_vt, *tolerance, residual, batch_size, scratchpad, scratchpad_size, {});
+   __FORCE_MKL_FLUSH__(status);
+   return 0;
+}
+
+extern "C" int onemklZgesvda_batch_strided(syclQueue_t device_queue, int64_t *iparm, int64_t *irank, int64_t m, int64_t n, double _Complex *a, int64_t lda, int64_t stride_a, double *s, int64_t stride_s, double _Complex *u, int64_t ldu, int64_t stride_u, double _Complex *vt, int64_t ldvt, int64_t stride_vt, double *tolerance, double *residual, int64_t batch_size, double _Complex *scratchpad, int64_t scratchpad_size) {
+   auto status = oneapi::mkl::lapack::gesvda_batch(device_queue->val, iparm, irank, m, n, reinterpret_cast<std::complex<double>*>(a), lda, stride_a, s, stride_s, reinterpret_cast<std::complex<double>*>(u), ldu, stride_u, reinterpret_cast<std::complex<double>*>(vt), ldvt, stride_vt, *tolerance, residual, batch_size, reinterpret_cast<std::complex<double>*>(scratchpad), scratchpad_size, {});
    __FORCE_MKL_FLUSH__(status);
    return 0;
 }
@@ -3559,6 +3655,78 @@ extern "C" int onemklZungqr_batch(syclQueue_t device_queue, int64_t *m, int64_t 
    return 0;
 }
 
+extern "C" int onemklSormqr_batch(syclQueue_t device_queue, onemklSide *side, onemklTranspose *trans, int64_t *m, int64_t *n, int64_t *k, float **a, int64_t *lda, float **tau, float **c, int64_t *ldc, int64_t group_count, int64_t *group_sizes, float *scratchpad, int64_t scratchpad_size) {
+   auto status = oneapi::mkl::lapack::ormqr_batch(device_queue->val, convert(side, group_count), convert(trans, group_count), m, n, k, a, lda, tau, c, ldc, group_count, group_sizes, scratchpad, scratchpad_size, {});
+   __FORCE_MKL_FLUSH__(status);
+   return 0;
+}
+
+extern "C" int onemklDormqr_batch(syclQueue_t device_queue, onemklSide *side, onemklTranspose *trans, int64_t *m, int64_t *n, int64_t *k, double **a, int64_t *lda, double **tau, double **c, int64_t *ldc, int64_t group_count, int64_t *group_sizes, double *scratchpad, int64_t scratchpad_size) {
+   auto status = oneapi::mkl::lapack::ormqr_batch(device_queue->val, convert(side, group_count), convert(trans, group_count), m, n, k, a, lda, tau, c, ldc, group_count, group_sizes, scratchpad, scratchpad_size, {});
+   __FORCE_MKL_FLUSH__(status);
+   return 0;
+}
+
+extern "C" int onemklCunmqr_batch(syclQueue_t device_queue, onemklSide *side, onemklTranspose *trans, int64_t *m, int64_t *n, int64_t *k, float _Complex **a, int64_t *lda, float _Complex **tau, float _Complex **c, int64_t *ldc, int64_t group_count, int64_t *group_sizes, float _Complex *scratchpad, int64_t scratchpad_size) {
+   auto status = oneapi::mkl::lapack::unmqr_batch(device_queue->val, convert(side, group_count), convert(trans, group_count), m, n, k, reinterpret_cast<std::complex<float>**>(a), lda, reinterpret_cast<std::complex<float>**>(tau), reinterpret_cast<std::complex<float>**>(c), ldc, group_count, group_sizes, reinterpret_cast<std::complex<float>*>(scratchpad), scratchpad_size, {});
+   __FORCE_MKL_FLUSH__(status);
+   return 0;
+}
+
+extern "C" int onemklZunmqr_batch(syclQueue_t device_queue, onemklSide *side, onemklTranspose *trans, int64_t *m, int64_t *n, int64_t *k, double _Complex **a, int64_t *lda, double _Complex **tau, double _Complex **c, int64_t *ldc, int64_t group_count, int64_t *group_sizes, double _Complex *scratchpad, int64_t scratchpad_size) {
+   auto status = oneapi::mkl::lapack::unmqr_batch(device_queue->val, convert(side, group_count), convert(trans, group_count), m, n, k, reinterpret_cast<std::complex<double>**>(a), lda, reinterpret_cast<std::complex<double>**>(tau), reinterpret_cast<std::complex<double>**>(c), ldc, group_count, group_sizes, reinterpret_cast<std::complex<double>*>(scratchpad), scratchpad_size, {});
+   __FORCE_MKL_FLUSH__(status);
+   return 0;
+}
+
+extern "C" int onemklStrtrs_batch(syclQueue_t device_queue, onemklUplo *uplo, onemklTranspose *trans, onemklDiag *diag, int64_t *n, int64_t *nrhs, float **a, int64_t *lda, float **b, int64_t *ldb, int64_t group_count, int64_t *group_sizes, float *scratchpad, int64_t scratchpad_size) {
+   auto status = oneapi::mkl::lapack::trtrs_batch(device_queue->val, convert(uplo, group_count), convert(trans, group_count), convert(diag, group_count), n, nrhs, a, lda, b, ldb, group_count, group_sizes, scratchpad, scratchpad_size, {});
+   __FORCE_MKL_FLUSH__(status);
+   return 0;
+}
+
+extern "C" int onemklDtrtrs_batch(syclQueue_t device_queue, onemklUplo *uplo, onemklTranspose *trans, onemklDiag *diag, int64_t *n, int64_t *nrhs, double **a, int64_t *lda, double **b, int64_t *ldb, int64_t group_count, int64_t *group_sizes, double *scratchpad, int64_t scratchpad_size) {
+   auto status = oneapi::mkl::lapack::trtrs_batch(device_queue->val, convert(uplo, group_count), convert(trans, group_count), convert(diag, group_count), n, nrhs, a, lda, b, ldb, group_count, group_sizes, scratchpad, scratchpad_size, {});
+   __FORCE_MKL_FLUSH__(status);
+   return 0;
+}
+
+extern "C" int onemklCtrtrs_batch(syclQueue_t device_queue, onemklUplo *uplo, onemklTranspose *trans, onemklDiag *diag, int64_t *n, int64_t *nrhs, float _Complex **a, int64_t *lda, float _Complex **b, int64_t *ldb, int64_t group_count, int64_t *group_sizes, float _Complex *scratchpad, int64_t scratchpad_size) {
+   auto status = oneapi::mkl::lapack::trtrs_batch(device_queue->val, convert(uplo, group_count), convert(trans, group_count), convert(diag, group_count), n, nrhs, reinterpret_cast<std::complex<float>**>(a), lda, reinterpret_cast<std::complex<float>**>(b), ldb, group_count, group_sizes, reinterpret_cast<std::complex<float>*>(scratchpad), scratchpad_size, {});
+   __FORCE_MKL_FLUSH__(status);
+   return 0;
+}
+
+extern "C" int onemklZtrtrs_batch(syclQueue_t device_queue, onemklUplo *uplo, onemklTranspose *trans, onemklDiag *diag, int64_t *n, int64_t *nrhs, double _Complex **a, int64_t *lda, double _Complex **b, int64_t *ldb, int64_t group_count, int64_t *group_sizes, double _Complex *scratchpad, int64_t scratchpad_size) {
+   auto status = oneapi::mkl::lapack::trtrs_batch(device_queue->val, convert(uplo, group_count), convert(trans, group_count), convert(diag, group_count), n, nrhs, reinterpret_cast<std::complex<double>**>(a), lda, reinterpret_cast<std::complex<double>**>(b), ldb, group_count, group_sizes, reinterpret_cast<std::complex<double>*>(scratchpad), scratchpad_size, {});
+   __FORCE_MKL_FLUSH__(status);
+   return 0;
+}
+
+extern "C" int onemklSgels_batch(syclQueue_t device_queue, onemklTranspose *trans, int64_t *m, int64_t *n, int64_t *nrhs, float **a, int64_t *lda, float **b, int64_t *ldb, int64_t group_count, int64_t *group_sizes, float *scratchpad, int64_t scratchpad_size) {
+   auto status = oneapi::mkl::lapack::gels_batch(device_queue->val, convert(trans, group_count), m, n, nrhs, a, lda, b, ldb, group_count, group_sizes, scratchpad, scratchpad_size, {});
+   __FORCE_MKL_FLUSH__(status);
+   return 0;
+}
+
+extern "C" int onemklDgels_batch(syclQueue_t device_queue, onemklTranspose *trans, int64_t *m, int64_t *n, int64_t *nrhs, double **a, int64_t *lda, double **b, int64_t *ldb, int64_t group_count, int64_t *group_sizes, double *scratchpad, int64_t scratchpad_size) {
+   auto status = oneapi::mkl::lapack::gels_batch(device_queue->val, convert(trans, group_count), m, n, nrhs, a, lda, b, ldb, group_count, group_sizes, scratchpad, scratchpad_size, {});
+   __FORCE_MKL_FLUSH__(status);
+   return 0;
+}
+
+extern "C" int onemklCgels_batch(syclQueue_t device_queue, onemklTranspose *trans, int64_t *m, int64_t *n, int64_t *nrhs, float _Complex **a, int64_t *lda,float _Complex **b, int64_t *ldb, int64_t group_count, int64_t *group_sizes, float _Complex *scratchpad, int64_t scratchpad_size) {
+   auto status = oneapi::mkl::lapack::gels_batch(device_queue->val, convert(trans, group_count), m, n, nrhs, reinterpret_cast<std::complex<float>**>(a), lda,reinterpret_cast<std::complex<float>**>(b), ldb, group_count, group_sizes, reinterpret_cast<std::complex<float>*>(scratchpad), scratchpad_size, {});
+   __FORCE_MKL_FLUSH__(status);
+   return 0;
+}
+
+extern "C" int onemklZgels_batch(syclQueue_t device_queue, onemklTranspose *trans, int64_t *m, int64_t *n, int64_t *nrhs, double _Complex **a, int64_t *lda, double _Complex **b, int64_t *ldb, int64_t group_count, int64_t *group_sizes, double _Complex *scratchpad, int64_t scratchpad_size) {
+   auto status = oneapi::mkl::lapack::gels_batch(device_queue->val, convert(trans, group_count), m, n, nrhs, reinterpret_cast<std::complex<double>**>(a), lda, reinterpret_cast<std::complex<double>**>(b), ldb, group_count, group_sizes, reinterpret_cast<std::complex<double>*>(scratchpad), scratchpad_size, {});
+   __FORCE_MKL_FLUSH__(status);
+   return 0;
+}
+
 extern "C" int64_t onemklSpotrf_batch_scratchpad_size(syclQueue_t device_queue, onemklUplo *uplo, int64_t *n, int64_t *lda, int64_t group_count, int64_t *group_sizes) {
    int64_t scratchpad_size = oneapi::mkl::lapack::potrf_batch_scratchpad_size<float>(device_queue->val, convert(uplo, group_count), n, lda, group_count, group_sizes);
    return scratchpad_size;
@@ -3696,6 +3864,66 @@ extern "C" int64_t onemklCungqr_batch_scratchpad_size(syclQueue_t device_queue, 
 
 extern "C" int64_t onemklZungqr_batch_scratchpad_size(syclQueue_t device_queue, int64_t *m, int64_t *n, int64_t *k, int64_t *lda, int64_t group_count, int64_t *group_sizes) {
    int64_t scratchpad_size = oneapi::mkl::lapack::ungqr_batch_scratchpad_size<std::complex<double>>(device_queue->val, m, n, k, lda, group_count, group_sizes);
+   return scratchpad_size;
+}
+
+extern "C" int64_t onemklSormqr_batch_scratchpad_size(syclQueue_t device_queue, onemklSide *side, onemklTranspose *trans, int64_t *m, int64_t *n, int64_t *k, int64_t *lda, int64_t *ldc, int64_t group_count, int64_t *group_sizes) {
+   int64_t scratchpad_size = oneapi::mkl::lapack::ormqr_batch_scratchpad_size<float>(device_queue->val, convert(side, group_count), convert(trans, group_count), m, n, k, lda, ldc, group_count, group_sizes);
+   return scratchpad_size;
+}
+
+extern "C" int64_t onemklDormqr_batch_scratchpad_size(syclQueue_t device_queue, onemklSide *side, onemklTranspose *trans, int64_t *m, int64_t *n, int64_t *k, int64_t *lda, int64_t *ldc, int64_t group_count, int64_t *group_sizes) {
+   int64_t scratchpad_size = oneapi::mkl::lapack::ormqr_batch_scratchpad_size<double>(device_queue->val, convert(side, group_count), convert(trans, group_count), m, n, k, lda, ldc, group_count, group_sizes);
+   return scratchpad_size;
+}
+
+extern "C" int64_t onemklCunmqr_batch_scratchpad_size(syclQueue_t device_queue, onemklSide *side, onemklTranspose *trans, int64_t *m, int64_t *n, int64_t *k, int64_t *lda, int64_t *ldc, int64_t group_count, int64_t *group_sizes) {
+   int64_t scratchpad_size = oneapi::mkl::lapack::unmqr_batch_scratchpad_size<std::complex<float>>(device_queue->val, convert(side, group_count), convert(trans, group_count), m, n, k, lda, ldc, group_count, group_sizes);
+   return scratchpad_size;
+}
+
+extern "C" int64_t onemklZunmqr_batch_scratchpad_size(syclQueue_t device_queue, onemklSide *side, onemklTranspose *trans, int64_t *m, int64_t *n, int64_t *k, int64_t *lda, int64_t *ldc, int64_t group_count, int64_t *group_sizes) {
+   int64_t scratchpad_size = oneapi::mkl::lapack::unmqr_batch_scratchpad_size<std::complex<double>>(device_queue->val, convert(side, group_count), convert(trans, group_count), m, n, k, lda, ldc, group_count, group_sizes);
+   return scratchpad_size;
+}
+
+extern "C" int64_t onemklStrtrs_batch_scratchpad_size(syclQueue_t device_queue, onemklUplo *uplo, onemklTranspose *trans, onemklDiag *diag, int64_t *n, int64_t *nrhs, int64_t *lda, int64_t *ldb, int64_t group_count, int64_t *group_sizes) {
+   int64_t scratchpad_size = oneapi::mkl::lapack::trtrs_batch_scratchpad_size<float>(device_queue->val, convert(uplo, group_count), convert(trans, group_count), convert(diag, group_count), n, nrhs, lda, ldb, group_count, group_sizes);
+   return scratchpad_size;
+}
+
+extern "C" int64_t onemklDtrtrs_batch_scratchpad_size(syclQueue_t device_queue, onemklUplo *uplo, onemklTranspose *trans, onemklDiag *diag, int64_t *n, int64_t *nrhs, int64_t *lda, int64_t *ldb, int64_t group_count, int64_t *group_sizes) {
+   int64_t scratchpad_size = oneapi::mkl::lapack::trtrs_batch_scratchpad_size<double>(device_queue->val, convert(uplo, group_count), convert(trans, group_count), convert(diag, group_count), n, nrhs, lda, ldb, group_count, group_sizes);
+   return scratchpad_size;
+}
+
+extern "C" int64_t onemklCtrtrs_batch_scratchpad_size(syclQueue_t device_queue, onemklUplo *uplo, onemklTranspose *trans, onemklDiag *diag, int64_t *n, int64_t *nrhs, int64_t *lda, int64_t *ldb, int64_t group_count, int64_t *group_sizes) {
+   int64_t scratchpad_size = oneapi::mkl::lapack::trtrs_batch_scratchpad_size<std::complex<float>>(device_queue->val, convert(uplo, group_count), convert(trans, group_count), convert(diag, group_count), n, nrhs, lda, ldb, group_count, group_sizes);
+   return scratchpad_size;
+}
+
+extern "C" int64_t onemklZtrtrs_batch_scratchpad_size(syclQueue_t device_queue, onemklUplo *uplo, onemklTranspose *trans, onemklDiag *diag, int64_t *n, int64_t *nrhs, int64_t *lda, int64_t *ldb, int64_t group_count, int64_t *group_sizes) {
+   int64_t scratchpad_size = oneapi::mkl::lapack::trtrs_batch_scratchpad_size<std::complex<double>>(device_queue->val, convert(uplo, group_count), convert(trans, group_count), convert(diag, group_count), n, nrhs, lda, ldb, group_count, group_sizes);
+   return scratchpad_size;
+}
+
+extern "C" int64_t onemklSgels_batch_scratchpad_size(syclQueue_t device_queue, onemklTranspose *trans, int64_t *m, int64_t *n, int64_t *nrhs, int64_t *lda, int64_t *ldb, int64_t group_count, int64_t *group_sizes) {
+   int64_t scratchpad_size = oneapi::mkl::lapack::gels_batch_scratchpad_size<float>(device_queue->val, convert(trans, group_count), m, n, nrhs, lda, ldb, group_count, group_sizes);
+   return scratchpad_size;
+}
+
+extern "C" int64_t onemklDgels_batch_scratchpad_size(syclQueue_t device_queue, onemklTranspose *trans, int64_t *m, int64_t *n, int64_t *nrhs, int64_t *lda, int64_t *ldb, int64_t group_count, int64_t *group_sizes) {
+   int64_t scratchpad_size = oneapi::mkl::lapack::gels_batch_scratchpad_size<double>(device_queue->val, convert(trans, group_count), m, n, nrhs, lda, ldb, group_count, group_sizes);
+   return scratchpad_size;
+}
+
+extern "C" int64_t onemklCgels_batch_scratchpad_size(syclQueue_t device_queue, onemklTranspose *trans, int64_t *m, int64_t *n, int64_t *nrhs, int64_t *lda, int64_t *ldb, int64_t group_count, int64_t *group_sizes) {
+   int64_t scratchpad_size = oneapi::mkl::lapack::gels_batch_scratchpad_size<std::complex<float>>(device_queue->val, convert(trans, group_count), m, n, nrhs, lda, ldb, group_count, group_sizes);
+   return scratchpad_size;
+}
+
+extern "C" int64_t onemklZgels_batch_scratchpad_size(syclQueue_t device_queue, onemklTranspose *trans, int64_t *m, int64_t *n, int64_t *nrhs, int64_t *lda, int64_t *ldb, int64_t group_count, int64_t *group_sizes) {
+   int64_t scratchpad_size = oneapi::mkl::lapack::gels_batch_scratchpad_size<std::complex<double>>(device_queue->val, convert(trans, group_count), m, n, nrhs, lda, ldb, group_count, group_sizes);
    return scratchpad_size;
 }
 
@@ -4014,6 +4242,54 @@ extern "C" int onemklZsparse_set_csr_data_64(syclQueue_t device_queue, matrix_ha
    return 0;
 }
 
+extern "C" int onemklSsparse_set_coo_data(syclQueue_t device_queue, matrix_handle_t spMat, int32_t nrows, int32_t ncols, int32_t nnz, onemklIndex index, int32_t *row_ind, int32_t *col_ind, float *values) {
+   auto status = oneapi::mkl::sparse::set_coo_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spMat, nrows, ncols, nnz, convert(index), row_ind, col_ind, values, {});
+   __FORCE_MKL_FLUSH__(status);
+   return 0;
+}
+
+extern "C" int onemklSsparse_set_coo_data_64(syclQueue_t device_queue, matrix_handle_t spMat, int64_t nrows, int64_t ncols, int64_t nnz, onemklIndex index, int64_t *row_ind, int64_t *col_ind, float *values) {
+   auto status = oneapi::mkl::sparse::set_coo_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spMat, nrows, ncols, nnz, convert(index), row_ind, col_ind, values, {});
+   __FORCE_MKL_FLUSH__(status);
+   return 0;
+}
+
+extern "C" int onemklDsparse_set_coo_data(syclQueue_t device_queue, matrix_handle_t spMat, int32_t nrows, int32_t ncols, int32_t nnz, onemklIndex index, int32_t *row_ind, int32_t *col_ind, double *values) {
+   auto status = oneapi::mkl::sparse::set_coo_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spMat, nrows, ncols, nnz, convert(index), row_ind, col_ind, values, {});
+   __FORCE_MKL_FLUSH__(status);
+   return 0;
+}
+
+extern "C" int onemklDsparse_set_coo_data_64(syclQueue_t device_queue, matrix_handle_t spMat, int64_t nrows, int64_t ncols, int64_t nnz, onemklIndex index, int64_t *row_ind, int64_t *col_ind, double *values) {
+   auto status = oneapi::mkl::sparse::set_coo_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spMat, nrows, ncols, nnz, convert(index), row_ind, col_ind, values, {});
+   __FORCE_MKL_FLUSH__(status);
+   return 0;
+}
+
+extern "C" int onemklCsparse_set_coo_data(syclQueue_t device_queue, matrix_handle_t spMat, int32_t nrows, int32_t ncols, int32_t nnz, onemklIndex index, int32_t *row_ind, int32_t *col_ind, float _Complex *values) {
+   auto status = oneapi::mkl::sparse::set_coo_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spMat, nrows, ncols, nnz, convert(index), row_ind, col_ind, reinterpret_cast<std::complex<float>*>(values), {});
+   __FORCE_MKL_FLUSH__(status);
+   return 0;
+}
+
+extern "C" int onemklCsparse_set_coo_data_64(syclQueue_t device_queue, matrix_handle_t spMat, int64_t nrows, int64_t ncols, int64_t nnz, onemklIndex index, int64_t *row_ind, int64_t *col_ind, float _Complex *values) {
+   auto status = oneapi::mkl::sparse::set_coo_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spMat, nrows, ncols, nnz, convert(index), row_ind, col_ind, reinterpret_cast<std::complex<float>*>(values), {});
+   __FORCE_MKL_FLUSH__(status);
+   return 0;
+}
+
+extern "C" int onemklZsparse_set_coo_data(syclQueue_t device_queue, matrix_handle_t spMat, int32_t nrows, int32_t ncols, int32_t nnz, onemklIndex index, int32_t *row_ind, int32_t *col_ind, double _Complex *values) {
+   auto status = oneapi::mkl::sparse::set_coo_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spMat, nrows, ncols, nnz, convert(index), row_ind, col_ind, reinterpret_cast<std::complex<double>*>(values), {});
+   __FORCE_MKL_FLUSH__(status);
+   return 0;
+}
+
+extern "C" int onemklZsparse_set_coo_data_64(syclQueue_t device_queue, matrix_handle_t spMat, int64_t nrows, int64_t ncols, int64_t nnz, onemklIndex index, int64_t *row_ind, int64_t *col_ind, double _Complex *values) {
+   auto status = oneapi::mkl::sparse::set_coo_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spMat, nrows, ncols, nnz, convert(index), row_ind, col_ind, reinterpret_cast<std::complex<double>*>(values), {});
+   __FORCE_MKL_FLUSH__(status);
+   return 0;
+}
+
 extern "C" int onemklXsparse_init_matmat_descr(matmat_descr_t *p_desc) {
    oneapi::mkl::sparse::init_matmat_descr((oneapi::mkl::sparse::matmat_descr_t*) p_desc);
    return 0;
@@ -4072,6 +4348,18 @@ extern "C" int onemklXsparse_optimize_trmv(syclQueue_t device_queue, onemklUplo 
 
 extern "C" int onemklXsparse_optimize_trsv(syclQueue_t device_queue, onemklUplo uplo_val, onemklTranspose opA, onemklDiag diag_val, matrix_handle_t A) {
    auto status = oneapi::mkl::sparse::optimize_trsv(device_queue->val, convert(uplo_val), convert(opA), convert(diag_val), (oneapi::mkl::sparse::matrix_handle_t) A, {});
+   return 0;
+}
+
+extern "C" int onemklXsparse_optimize_trsm(syclQueue_t device_queue, onemklUplo uplo_val, onemklTranspose opA, onemklDiag diag_val, matrix_handle_t A) {
+   auto status = oneapi::mkl::sparse::optimize_trsm(device_queue->val, convert(uplo_val), convert(opA), convert(diag_val), (oneapi::mkl::sparse::matrix_handle_t) A, {});
+   __FORCE_MKL_FLUSH__(status);
+   return 0;
+}
+
+extern "C" int onemklXsparse_optimize_trsm_advanced(syclQueue_t device_queue, onemklLayout layout_val, onemklUplo uplo_val, onemklTranspose opA, onemklDiag diag_val, matrix_handle_t A, int64_t columns) {
+   auto status = oneapi::mkl::sparse::optimize_trsm(device_queue->val, convert(layout_val), convert(uplo_val), convert(opA), convert(diag_val), (oneapi::mkl::sparse::matrix_handle_t) A, columns, {});
+   __FORCE_MKL_FLUSH__(status);
    return 0;
 }
 
@@ -4171,26 +4459,26 @@ extern "C" int onemklZsparse_trmv(syclQueue_t device_queue, onemklUplo uplo_val,
    return 0;
 }
 
-extern "C" int onemklSsparse_trsv(syclQueue_t device_queue, onemklUplo uplo_val, onemklTranspose opA, onemklDiag diag_val, matrix_handle_t A, float *x, float *y) {
-   auto status = oneapi::mkl::sparse::trsv(device_queue->val, convert(uplo_val), convert(opA), convert(diag_val), (oneapi::mkl::sparse::matrix_handle_t) A, x, y, {});
+extern "C" int onemklSsparse_trsv(syclQueue_t device_queue, onemklUplo uplo_val, onemklTranspose opA, onemklDiag diag_val, float *alpha, matrix_handle_t A, float *x, float *y) {
+   auto status = oneapi::mkl::sparse::trsv(device_queue->val, convert(uplo_val), convert(opA), convert(diag_val), *alpha, (oneapi::mkl::sparse::matrix_handle_t) A, x, y, {});
    __FORCE_MKL_FLUSH__(status);
    return 0;
 }
 
-extern "C" int onemklDsparse_trsv(syclQueue_t device_queue, onemklUplo uplo_val, onemklTranspose opA, onemklDiag diag_val, matrix_handle_t A, double *x, double *y) {
-   auto status = oneapi::mkl::sparse::trsv(device_queue->val, convert(uplo_val), convert(opA), convert(diag_val), (oneapi::mkl::sparse::matrix_handle_t) A, x, y, {});
+extern "C" int onemklDsparse_trsv(syclQueue_t device_queue, onemklUplo uplo_val, onemklTranspose opA, onemklDiag diag_val, double *alpha, matrix_handle_t A, double *x, double *y) {
+   auto status = oneapi::mkl::sparse::trsv(device_queue->val, convert(uplo_val), convert(opA), convert(diag_val), *alpha, (oneapi::mkl::sparse::matrix_handle_t) A, x, y, {});
    __FORCE_MKL_FLUSH__(status);
    return 0;
 }
 
-extern "C" int onemklCsparse_trsv(syclQueue_t device_queue, onemklUplo uplo_val, onemklTranspose opA, onemklDiag diag_val, matrix_handle_t A, float _Complex *x, float _Complex *y) {
-   auto status = oneapi::mkl::sparse::trsv(device_queue->val, convert(uplo_val), convert(opA), convert(diag_val), (oneapi::mkl::sparse::matrix_handle_t) A, reinterpret_cast<std::complex<float>*>(x), reinterpret_cast<std::complex<float>*>(y), {});
+extern "C" int onemklCsparse_trsv(syclQueue_t device_queue, onemklUplo uplo_val, onemklTranspose opA, onemklDiag diag_val, float _Complex *alpha, matrix_handle_t A, float _Complex *x, float _Complex *y) {
+   auto status = oneapi::mkl::sparse::trsv(device_queue->val, convert(uplo_val), convert(opA), convert(diag_val), *reinterpret_cast<std::complex<float>*>(alpha), (oneapi::mkl::sparse::matrix_handle_t) A, reinterpret_cast<std::complex<float>*>(x), reinterpret_cast<std::complex<float>*>(y), {});
    __FORCE_MKL_FLUSH__(status);
    return 0;
 }
 
-extern "C" int onemklZsparse_trsv(syclQueue_t device_queue, onemklUplo uplo_val, onemklTranspose opA, onemklDiag diag_val, matrix_handle_t A, double _Complex *x, double _Complex *y) {
-   auto status = oneapi::mkl::sparse::trsv(device_queue->val, convert(uplo_val), convert(opA), convert(diag_val), (oneapi::mkl::sparse::matrix_handle_t) A, reinterpret_cast<std::complex<double>*>(x), reinterpret_cast<std::complex<double>*>(y), {});
+extern "C" int onemklZsparse_trsv(syclQueue_t device_queue, onemklUplo uplo_val, onemklTranspose opA, onemklDiag diag_val, double _Complex *alpha, matrix_handle_t A, double _Complex *x, double _Complex *y) {
+   auto status = oneapi::mkl::sparse::trsv(device_queue->val, convert(uplo_val), convert(opA), convert(diag_val), *reinterpret_cast<std::complex<double>*>(alpha), (oneapi::mkl::sparse::matrix_handle_t) A, reinterpret_cast<std::complex<double>*>(x), reinterpret_cast<std::complex<double>*>(y), {});
    __FORCE_MKL_FLUSH__(status);
    return 0;
 }
@@ -4215,6 +4503,30 @@ extern "C" int onemklCsparse_gemm(syclQueue_t device_queue, onemklLayout layout_
 
 extern "C" int onemklZsparse_gemm(syclQueue_t device_queue, onemklLayout layout_val, onemklTranspose opA, onemklTranspose opX, double _Complex *alpha, matrix_handle_t A, double _Complex *X, int64_t columns, int64_t ldx, double _Complex *beta, double _Complex *Y, int64_t ldy) {
    auto status = oneapi::mkl::sparse::gemm(device_queue->val, convert(layout_val), convert(opA), convert(opX), *reinterpret_cast<std::complex<double>*>(alpha), (oneapi::mkl::sparse::matrix_handle_t) A, reinterpret_cast<std::complex<double>*>(X), columns, ldx, *reinterpret_cast<std::complex<double>*>(beta), reinterpret_cast<std::complex<double>*>(Y), ldy, {});
+   __FORCE_MKL_FLUSH__(status);
+   return 0;
+}
+
+extern "C" int onemklSsparse_trsm(syclQueue_t device_queue, onemklLayout layout_val, onemklTranspose opA, onemklTranspose opX, onemklUplo uplo_val, onemklDiag diag_val, float *alpha, matrix_handle_t A, float *X, int64_t columns, int64_t ldx, float *Y, int64_t ldy) {
+   auto status = oneapi::mkl::sparse::trsm(device_queue->val, convert(layout_val), convert(opA), convert(opX), convert(uplo_val), convert(diag_val), *alpha, (oneapi::mkl::sparse::matrix_handle_t) A, X, columns, ldx, Y, ldy, {});
+   __FORCE_MKL_FLUSH__(status);
+   return 0;
+}
+
+extern "C" int onemklDsparse_trsm(syclQueue_t device_queue, onemklLayout layout_val, onemklTranspose opA, onemklTranspose opX, onemklUplo uplo_val, onemklDiag diag_val, double *alpha, matrix_handle_t A, double *X, int64_t columns, int64_t ldx, double *Y, int64_t ldy) {
+   auto status = oneapi::mkl::sparse::trsm(device_queue->val, convert(layout_val), convert(opA), convert(opX), convert(uplo_val), convert(diag_val), *alpha, (oneapi::mkl::sparse::matrix_handle_t) A, X, columns, ldx, Y, ldy, {});
+   __FORCE_MKL_FLUSH__(status);
+   return 0;
+}
+
+extern "C" int onemklCsparse_trsm(syclQueue_t device_queue, onemklLayout layout_val, onemklTranspose opA, onemklTranspose opX, onemklUplo uplo_val, onemklDiag diag_val, float _Complex *alpha, matrix_handle_t A, float _Complex *X, int64_t columns, int64_t ldx, float _Complex *Y, int64_t ldy) {
+   auto status = oneapi::mkl::sparse::trsm(device_queue->val, convert(layout_val), convert(opA), convert(opX), convert(uplo_val), convert(diag_val), *reinterpret_cast<std::complex<float>*>(alpha), (oneapi::mkl::sparse::matrix_handle_t) A, reinterpret_cast<std::complex<float>*>(X), columns, ldx, reinterpret_cast<std::complex<float>*>(Y), ldy, {});
+   __FORCE_MKL_FLUSH__(status);
+   return 0;
+}
+
+extern "C" int onemklZsparse_trsm(syclQueue_t device_queue, onemklLayout layout_val, onemklTranspose opA, onemklTranspose opX, onemklUplo uplo_val, onemklDiag diag_val, double _Complex *alpha, matrix_handle_t A, double _Complex *X, int64_t columns, int64_t ldx, double _Complex *Y, int64_t ldy) {
+   auto status = oneapi::mkl::sparse::trsm(device_queue->val, convert(layout_val), convert(opA), convert(opX), convert(uplo_val), convert(diag_val), *reinterpret_cast<std::complex<double>*>(alpha), (oneapi::mkl::sparse::matrix_handle_t) A, reinterpret_cast<std::complex<double>*>(X), columns, ldx, reinterpret_cast<std::complex<double>*>(Y), ldy, {});
    __FORCE_MKL_FLUSH__(status);
    return 0;
 }

--- a/deps/src/onemkl.h
+++ b/deps/src/onemkl.h
@@ -597,29 +597,53 @@ int onemklCdotu(syclQueue_t device_queue, int64_t n, float _Complex *x, int64_t 
 int onemklZdotu(syclQueue_t device_queue, int64_t n, double _Complex *x, int64_t incx, double
                 _Complex *y, int64_t incy, double _Complex *result);
 
-int onemklSiamax(syclQueue_t device_queue, int64_t n, float *x, int64_t incx, int64_t *result,
+int onemklSiamax(syclQueue_t device_queue, int64_t n, float *x, int64_t incx, int32_t *result,
                  onemklIndex base);
 
-int onemklDiamax(syclQueue_t device_queue, int64_t n, double *x, int64_t incx, int64_t *result,
+int onemklSiamax_64(syclQueue_t device_queue, int64_t n, float *x, int64_t incx, int64_t *result,
+                    onemklIndex base);
+
+int onemklDiamax(syclQueue_t device_queue, int64_t n, double *x, int64_t incx, int32_t *result,
                  onemklIndex base);
 
-int onemklCiamax(syclQueue_t device_queue, int64_t n, float _Complex *x, int64_t incx, int64_t
+int onemklDiamax_64(syclQueue_t device_queue, int64_t n, double *x, int64_t incx, int64_t *result,
+                    onemklIndex base);
+
+int onemklCiamax(syclQueue_t device_queue, int64_t n, float _Complex *x, int64_t incx, int32_t
                  *result, onemklIndex base);
 
-int onemklZiamax(syclQueue_t device_queue, int64_t n, double _Complex *x, int64_t incx, int64_t
+int onemklCiamax_64(syclQueue_t device_queue, int64_t n, float _Complex *x, int64_t incx, int64_t
+                    *result, onemklIndex base);
+
+int onemklZiamax(syclQueue_t device_queue, int64_t n, double _Complex *x, int64_t incx, int32_t
                  *result, onemklIndex base);
 
-int onemklSiamin(syclQueue_t device_queue, int64_t n, float *x, int64_t incx, int64_t *result,
+int onemklZiamax_64(syclQueue_t device_queue, int64_t n, double _Complex *x, int64_t incx, int64_t
+                    *result, onemklIndex base);
+
+int onemklSiamin(syclQueue_t device_queue, int64_t n, float *x, int64_t incx, int32_t *result,
                  onemklIndex base);
 
-int onemklDiamin(syclQueue_t device_queue, int64_t n, double *x, int64_t incx, int64_t *result,
+int onemklSiamin_64(syclQueue_t device_queue, int64_t n, float *x, int64_t incx, int64_t *result,
+                    onemklIndex base);
+
+int onemklDiamin(syclQueue_t device_queue, int64_t n, double *x, int64_t incx, int32_t *result,
                  onemklIndex base);
 
-int onemklCiamin(syclQueue_t device_queue, int64_t n, float _Complex *x, int64_t incx, int64_t
+int onemklDiamin_64(syclQueue_t device_queue, int64_t n, double *x, int64_t incx, int64_t *result,
+                    onemklIndex base);
+
+int onemklCiamin(syclQueue_t device_queue, int64_t n, float _Complex *x, int64_t incx, int32_t
                  *result, onemklIndex base);
 
-int onemklZiamin(syclQueue_t device_queue, int64_t n, double _Complex *x, int64_t incx, int64_t
+int onemklCiamin_64(syclQueue_t device_queue, int64_t n, float _Complex *x, int64_t incx, int64_t
+                    *result, onemklIndex base);
+
+int onemklZiamin(syclQueue_t device_queue, int64_t n, double _Complex *x, int64_t incx, int32_t
                  *result, onemklIndex base);
+
+int onemklZiamin_64(syclQueue_t device_queue, int64_t n, double _Complex *x, int64_t incx, int64_t
+                    *result, onemklIndex base);
 
 int onemklSasum(syclQueue_t device_queue, int64_t n, float *x, int64_t incx, float *result);
 
@@ -1227,6 +1251,59 @@ int onemklDgesvd(syclQueue_t device_queue, onemklJobsvd jobu, onemklJobsvd jobvt
 int onemklSgesvd(syclQueue_t device_queue, onemklJobsvd jobu, onemklJobsvd jobvt, int64_t m,
                  int64_t n, float *a, int64_t lda, float *s, float *u, int64_t ldu, float *vt, int64_t
                  ldvt, float *scratchpad, int64_t scratchpad_size);
+
+int64_t onemklSgesvda_batch_strided_scratchpad_size(syclQueue_t device_queue, int64_t m,
+                                                    int64_t n, int64_t lda, int64_t stride_a,
+                                                    int64_t stride_s, int64_t ldu, int64_t
+                                                    stride_u, int64_t ldvt, int64_t stride_vt,
+                                                    int64_t batch_size);
+
+int64_t onemklDgesvda_batch_strided_scratchpad_size(syclQueue_t device_queue, int64_t m,
+                                                    int64_t n, int64_t lda, int64_t stride_a,
+                                                    int64_t stride_s, int64_t ldu, int64_t
+                                                    stride_u, int64_t ldvt, int64_t stride_vt,
+                                                    int64_t batch_size);
+
+int64_t onemklCgesvda_batch_strided_scratchpad_size(syclQueue_t device_queue, int64_t m,
+                                                    int64_t n, int64_t lda, int64_t stride_a,
+                                                    int64_t stride_s, int64_t ldu, int64_t
+                                                    stride_u, int64_t ldvt, int64_t stride_vt,
+                                                    int64_t batch_size);
+
+int64_t onemklZgesvda_batch_strided_scratchpad_size(syclQueue_t device_queue, int64_t m,
+                                                    int64_t n, int64_t lda, int64_t stride_a,
+                                                    int64_t stride_s, int64_t ldu, int64_t
+                                                    stride_u, int64_t ldvt, int64_t stride_vt,
+                                                    int64_t batch_size);
+
+int onemklCgesvda_batch_strided(syclQueue_t device_queue, int64_t *iparm, int64_t *irank, int64_t
+                                m, int64_t n, float _Complex *a, int64_t lda, int64_t stride_a,
+                                float *s, int64_t stride_s, float _Complex *u, int64_t ldu, int64_t
+                                stride_u, float _Complex *vt, int64_t ldvt, int64_t stride_vt,
+                                float *tolerance, float *residual, int64_t batch_size, float
+                                _Complex *scratchpad, int64_t scratchpad_size);
+
+int onemklDgesvda_batch_strided(syclQueue_t device_queue, int64_t *iparm, int64_t *irank, int64_t
+                                m, int64_t n, double *a, int64_t lda, int64_t stride_a, double *s,
+                                int64_t stride_s, double *u, int64_t ldu, int64_t stride_u, double
+                                *vt, int64_t ldvt, int64_t stride_vt, double *tolerance, double
+                                *residual, int64_t batch_size, double *scratchpad, int64_t
+                                scratchpad_size);
+
+int onemklSgesvda_batch_strided(syclQueue_t device_queue, int64_t *iparm, int64_t *irank, int64_t
+                                m, int64_t n, float *a, int64_t lda, int64_t stride_a, float *s,
+                                int64_t stride_s, float *u, int64_t ldu, int64_t stride_u, float
+                                *vt, int64_t ldvt, int64_t stride_vt, float *tolerance, float
+                                *residual, int64_t batch_size, float *scratchpad, int64_t
+                                scratchpad_size);
+
+int onemklZgesvda_batch_strided(syclQueue_t device_queue, int64_t *iparm, int64_t *irank, int64_t
+                                m, int64_t n, double _Complex *a, int64_t lda, int64_t stride_a,
+                                double *s, int64_t stride_s, double _Complex *u, int64_t ldu,
+                                int64_t stride_u, double _Complex *vt, int64_t ldvt, int64_t
+                                stride_vt, double *tolerance, double *residual, int64_t
+                                batch_size, double _Complex *scratchpad, int64_t
+                                scratchpad_size);
 
 int64_t onemklSgetrf_scratchpad_size(syclQueue_t device_queue, int64_t m, int64_t n, int64_t lda);
 
@@ -2092,6 +2169,68 @@ int onemklZungqr_batch(syclQueue_t device_queue, int64_t *m, int64_t *n, int64_t
                        **a, int64_t *lda, double _Complex **tau, int64_t group_count, int64_t
                        *group_sizes, double _Complex *scratchpad, int64_t scratchpad_size);
 
+int onemklSormqr_batch(syclQueue_t device_queue, onemklSide *side, onemklTranspose *trans,
+                       int64_t *m, int64_t *n, int64_t *k, float **a, int64_t *lda, float **tau, float
+                       **c, int64_t *ldc, int64_t group_count, int64_t *group_sizes, float
+                       *scratchpad, int64_t scratchpad_size);
+
+int onemklDormqr_batch(syclQueue_t device_queue, onemklSide *side, onemklTranspose *trans,
+                       int64_t *m, int64_t *n, int64_t *k, double **a, int64_t *lda, double **tau,
+                       double **c, int64_t *ldc, int64_t group_count, int64_t *group_sizes, double
+                       *scratchpad, int64_t scratchpad_size);
+
+int onemklCunmqr_batch(syclQueue_t device_queue, onemklSide *side, onemklTranspose *trans,
+                       int64_t *m, int64_t *n, int64_t *k, float _Complex **a, int64_t *lda, float
+                       _Complex **tau, float _Complex **c, int64_t *ldc, int64_t group_count,
+                       int64_t *group_sizes, float _Complex *scratchpad, int64_t
+                       scratchpad_size);
+
+int onemklZunmqr_batch(syclQueue_t device_queue, onemklSide *side, onemklTranspose *trans,
+                       int64_t *m, int64_t *n, int64_t *k, double _Complex **a, int64_t *lda, double
+                       _Complex **tau, double _Complex **c, int64_t *ldc, int64_t group_count,
+                       int64_t *group_sizes, double _Complex *scratchpad, int64_t
+                       scratchpad_size);
+
+int onemklStrtrs_batch(syclQueue_t device_queue, onemklUplo *uplo, onemklTranspose *trans,
+                       onemklDiag *diag, int64_t *n, int64_t *nrhs, float **a, int64_t *lda, float
+                       **b, int64_t *ldb, int64_t group_count, int64_t *group_sizes, float
+                       *scratchpad, int64_t scratchpad_size);
+
+int onemklDtrtrs_batch(syclQueue_t device_queue, onemklUplo *uplo, onemklTranspose *trans,
+                       onemklDiag *diag, int64_t *n, int64_t *nrhs, double **a, int64_t *lda, double
+                       **b, int64_t *ldb, int64_t group_count, int64_t *group_sizes, double
+                       *scratchpad, int64_t scratchpad_size);
+
+int onemklCtrtrs_batch(syclQueue_t device_queue, onemklUplo *uplo, onemklTranspose *trans,
+                       onemklDiag *diag, int64_t *n, int64_t *nrhs, float _Complex **a, int64_t
+                       *lda, float _Complex **b, int64_t *ldb, int64_t group_count, int64_t
+                       *group_sizes, float _Complex *scratchpad, int64_t scratchpad_size);
+
+int onemklZtrtrs_batch(syclQueue_t device_queue, onemklUplo *uplo, onemklTranspose *trans,
+                       onemklDiag *diag, int64_t *n, int64_t *nrhs, double _Complex **a, int64_t
+                       *lda, double _Complex **b, int64_t *ldb, int64_t group_count, int64_t
+                       *group_sizes, double _Complex *scratchpad, int64_t scratchpad_size);
+
+int onemklSgels_batch(syclQueue_t device_queue, onemklTranspose *trans, int64_t *m, int64_t *n,
+                      int64_t *nrhs, float **a, int64_t *lda, float **b, int64_t *ldb, int64_t
+                      group_count, int64_t *group_sizes, float *scratchpad, int64_t
+                      scratchpad_size);
+
+int onemklDgels_batch(syclQueue_t device_queue, onemklTranspose *trans, int64_t *m, int64_t *n,
+                      int64_t *nrhs, double **a, int64_t *lda, double **b, int64_t *ldb, int64_t
+                      group_count, int64_t *group_sizes, double *scratchpad, int64_t
+                      scratchpad_size);
+
+int onemklCgels_batch(syclQueue_t device_queue, onemklTranspose *trans, int64_t *m, int64_t *n,
+                      int64_t *nrhs, float _Complex **a, int64_t *lda,float _Complex **b, int64_t
+                      *ldb, int64_t group_count, int64_t *group_sizes, float _Complex
+                      *scratchpad, int64_t scratchpad_size);
+
+int onemklZgels_batch(syclQueue_t device_queue, onemklTranspose *trans, int64_t *m, int64_t *n,
+                      int64_t *nrhs, double _Complex **a, int64_t *lda, double _Complex **b, int64_t
+                      *ldb, int64_t group_count, int64_t *group_sizes, double _Complex
+                      *scratchpad, int64_t scratchpad_size);
+
 int64_t onemklSpotrf_batch_scratchpad_size(syclQueue_t device_queue, onemklUplo *uplo, int64_t
                                            *n, int64_t *lda, int64_t group_count, int64_t
                                            *group_sizes);
@@ -2195,6 +2334,66 @@ int64_t onemklCungqr_batch_scratchpad_size(syclQueue_t device_queue, int64_t *m,
 int64_t onemklZungqr_batch_scratchpad_size(syclQueue_t device_queue, int64_t *m, int64_t *n,
                                            int64_t *k, int64_t *lda, int64_t group_count,
                                            int64_t *group_sizes);
+
+int64_t onemklSormqr_batch_scratchpad_size(syclQueue_t device_queue, onemklSide *side,
+                                           onemklTranspose *trans, int64_t *m, int64_t *n,
+                                           int64_t *k, int64_t *lda, int64_t *ldc, int64_t
+                                           group_count, int64_t *group_sizes);
+
+int64_t onemklDormqr_batch_scratchpad_size(syclQueue_t device_queue, onemklSide *side,
+                                           onemklTranspose *trans, int64_t *m, int64_t *n,
+                                           int64_t *k, int64_t *lda, int64_t *ldc, int64_t
+                                           group_count, int64_t *group_sizes);
+
+int64_t onemklCunmqr_batch_scratchpad_size(syclQueue_t device_queue, onemklSide *side,
+                                           onemklTranspose *trans, int64_t *m, int64_t *n,
+                                           int64_t *k, int64_t *lda, int64_t *ldc, int64_t
+                                           group_count, int64_t *group_sizes);
+
+int64_t onemklZunmqr_batch_scratchpad_size(syclQueue_t device_queue, onemklSide *side,
+                                           onemklTranspose *trans, int64_t *m, int64_t *n,
+                                           int64_t *k, int64_t *lda, int64_t *ldc, int64_t
+                                           group_count, int64_t *group_sizes);
+
+int64_t onemklStrtrs_batch_scratchpad_size(syclQueue_t device_queue, onemklUplo *uplo,
+                                           onemklTranspose *trans, onemklDiag *diag, int64_t
+                                           *n, int64_t *nrhs, int64_t *lda, int64_t *ldb, int64_t
+                                           group_count, int64_t *group_sizes);
+
+int64_t onemklDtrtrs_batch_scratchpad_size(syclQueue_t device_queue, onemklUplo *uplo,
+                                           onemklTranspose *trans, onemklDiag *diag, int64_t
+                                           *n, int64_t *nrhs, int64_t *lda, int64_t *ldb, int64_t
+                                           group_count, int64_t *group_sizes);
+
+int64_t onemklCtrtrs_batch_scratchpad_size(syclQueue_t device_queue, onemklUplo *uplo,
+                                           onemklTranspose *trans, onemklDiag *diag, int64_t
+                                           *n, int64_t *nrhs, int64_t *lda, int64_t *ldb, int64_t
+                                           group_count, int64_t *group_sizes);
+
+int64_t onemklZtrtrs_batch_scratchpad_size(syclQueue_t device_queue, onemklUplo *uplo,
+                                           onemklTranspose *trans, onemklDiag *diag, int64_t
+                                           *n, int64_t *nrhs, int64_t *lda, int64_t *ldb, int64_t
+                                           group_count, int64_t *group_sizes);
+
+int64_t onemklSgels_batch_scratchpad_size(syclQueue_t device_queue, onemklTranspose *trans,
+                                          int64_t *m, int64_t *n, int64_t *nrhs, int64_t *lda,
+                                          int64_t *ldb, int64_t group_count, int64_t
+                                          *group_sizes);
+
+int64_t onemklDgels_batch_scratchpad_size(syclQueue_t device_queue, onemklTranspose *trans,
+                                          int64_t *m, int64_t *n, int64_t *nrhs, int64_t *lda,
+                                          int64_t *ldb, int64_t group_count, int64_t
+                                          *group_sizes);
+
+int64_t onemklCgels_batch_scratchpad_size(syclQueue_t device_queue, onemklTranspose *trans,
+                                          int64_t *m, int64_t *n, int64_t *nrhs, int64_t *lda,
+                                          int64_t *ldb, int64_t group_count, int64_t
+                                          *group_sizes);
+
+int64_t onemklZgels_batch_scratchpad_size(syclQueue_t device_queue, onemklTranspose *trans,
+                                          int64_t *m, int64_t *n, int64_t *nrhs, int64_t *lda,
+                                          int64_t *ldb, int64_t group_count, int64_t
+                                          *group_sizes);
 
 int onemklSpotrf_batch_strided(syclQueue_t device_queue, onemklUplo uplo, int64_t n, float *a,
                                int64_t lda, int64_t stride_a, int64_t batch_size, float
@@ -2446,6 +2645,38 @@ int onemklZsparse_set_csr_data_64(syclQueue_t device_queue, matrix_handle_t spMa
                                   nrows, int64_t ncols, onemklIndex index, int64_t *row_ptr,
                                   int64_t *col_ind, double _Complex *values);
 
+int onemklSsparse_set_coo_data(syclQueue_t device_queue, matrix_handle_t spMat, int32_t nrows,
+                               int32_t ncols, int32_t nnz, onemklIndex index, int32_t *row_ind,
+                               int32_t *col_ind, float *values);
+
+int onemklSsparse_set_coo_data_64(syclQueue_t device_queue, matrix_handle_t spMat, int64_t
+                                  nrows, int64_t ncols, int64_t nnz, onemklIndex index, int64_t
+                                  *row_ind, int64_t *col_ind, float *values);
+
+int onemklDsparse_set_coo_data(syclQueue_t device_queue, matrix_handle_t spMat, int32_t nrows,
+                               int32_t ncols, int32_t nnz, onemklIndex index, int32_t *row_ind,
+                               int32_t *col_ind, double *values);
+
+int onemklDsparse_set_coo_data_64(syclQueue_t device_queue, matrix_handle_t spMat, int64_t
+                                  nrows, int64_t ncols, int64_t nnz, onemklIndex index, int64_t
+                                  *row_ind, int64_t *col_ind, double *values);
+
+int onemklCsparse_set_coo_data(syclQueue_t device_queue, matrix_handle_t spMat, int32_t nrows,
+                               int32_t ncols, int32_t nnz, onemklIndex index, int32_t *row_ind,
+                               int32_t *col_ind, float _Complex *values);
+
+int onemklCsparse_set_coo_data_64(syclQueue_t device_queue, matrix_handle_t spMat, int64_t
+                                  nrows, int64_t ncols, int64_t nnz, onemklIndex index, int64_t
+                                  *row_ind, int64_t *col_ind, float _Complex *values);
+
+int onemklZsparse_set_coo_data(syclQueue_t device_queue, matrix_handle_t spMat, int32_t nrows,
+                               int32_t ncols, int32_t nnz, onemklIndex index, int32_t *row_ind,
+                               int32_t *col_ind, double _Complex *values);
+
+int onemklZsparse_set_coo_data_64(syclQueue_t device_queue, matrix_handle_t spMat, int64_t
+                                  nrows, int64_t ncols, int64_t nnz, onemklIndex index, int64_t
+                                  *row_ind, int64_t *col_ind, double _Complex *values);
+
 int onemklXsparse_init_matmat_descr(matmat_descr_t *p_desc);
 
 int onemklXsparse_release_matmat_descr(matmat_descr_t *p_desc);
@@ -2475,6 +2706,13 @@ int onemklXsparse_optimize_trmv(syclQueue_t device_queue, onemklUplo uplo_val, o
 
 int onemklXsparse_optimize_trsv(syclQueue_t device_queue, onemklUplo uplo_val, onemklTranspose
                                 opA, onemklDiag diag_val, matrix_handle_t A);
+
+int onemklXsparse_optimize_trsm(syclQueue_t device_queue, onemklUplo uplo_val, onemklTranspose
+                                opA, onemklDiag diag_val, matrix_handle_t A);
+
+int onemklXsparse_optimize_trsm_advanced(syclQueue_t device_queue, onemklLayout layout_val,
+                                         onemklUplo uplo_val, onemklTranspose opA, onemklDiag
+                                         diag_val, matrix_handle_t A, int64_t columns);
 
 int onemklSsparse_gemv(syclQueue_t device_queue, onemklTranspose opA, float *alpha,
                        matrix_handle_t A, float *x, float *beta, float *y);
@@ -2535,17 +2773,17 @@ int onemklZsparse_trmv(syclQueue_t device_queue, onemklUplo uplo_val, onemklTran
                        _Complex *x, double _Complex *beta, double _Complex *y);
 
 int onemklSsparse_trsv(syclQueue_t device_queue, onemklUplo uplo_val, onemklTranspose opA,
-                       onemklDiag diag_val, matrix_handle_t A, float *x, float *y);
+                       onemklDiag diag_val, float *alpha, matrix_handle_t A, float *x, float *y);
 
 int onemklDsparse_trsv(syclQueue_t device_queue, onemklUplo uplo_val, onemklTranspose opA,
-                       onemklDiag diag_val, matrix_handle_t A, double *x, double *y);
+                       onemklDiag diag_val, double *alpha, matrix_handle_t A, double *x, double *y);
 
 int onemklCsparse_trsv(syclQueue_t device_queue, onemklUplo uplo_val, onemklTranspose opA,
-                       onemklDiag diag_val, matrix_handle_t A, float
+                       onemklDiag diag_val, float _Complex *alpha, matrix_handle_t A, float
                        _Complex *x, float _Complex *y);
 
 int onemklZsparse_trsv(syclQueue_t device_queue, onemklUplo uplo_val, onemklTranspose opA,
-                       onemklDiag diag_val, matrix_handle_t A, double
+                       onemklDiag diag_val, double _Complex *alpha, matrix_handle_t A, double
                        _Complex *x, double _Complex *y);
 
 int onemklSsparse_gemm(syclQueue_t device_queue, onemklLayout layout_val, onemklTranspose opA,
@@ -2565,6 +2803,26 @@ int onemklZsparse_gemm(syclQueue_t device_queue, onemklLayout layout_val, onemkl
                        onemklTranspose opX, double _Complex *alpha, matrix_handle_t A, double
                        _Complex *X, int64_t columns, int64_t ldx, double _Complex *beta, double
                        _Complex *Y, int64_t ldy);
+
+int onemklSsparse_trsm(syclQueue_t device_queue, onemklLayout layout_val, onemklTranspose opA,
+                       onemklTranspose opX, onemklUplo uplo_val, onemklDiag diag_val, float
+                       *alpha, matrix_handle_t A, float *X, int64_t columns, int64_t ldx, float *Y,
+                       int64_t ldy);
+
+int onemklDsparse_trsm(syclQueue_t device_queue, onemklLayout layout_val, onemklTranspose opA,
+                       onemklTranspose opX, onemklUplo uplo_val, onemklDiag diag_val, double
+                       *alpha, matrix_handle_t A, double *X, int64_t columns, int64_t ldx, double
+                       *Y, int64_t ldy);
+
+int onemklCsparse_trsm(syclQueue_t device_queue, onemklLayout layout_val, onemklTranspose opA,
+                       onemklTranspose opX, onemklUplo uplo_val, onemklDiag diag_val, float
+                       _Complex *alpha, matrix_handle_t A, float _Complex *X, int64_t columns,
+                       int64_t ldx, float _Complex *Y, int64_t ldy);
+
+int onemklZsparse_trsm(syclQueue_t device_queue, onemklLayout layout_val, onemklTranspose opA,
+                       onemklTranspose opX, onemklUplo uplo_val, onemklDiag diag_val, double
+                       _Complex *alpha, matrix_handle_t A, double _Complex *X, int64_t columns,
+                       int64_t ldx, double _Complex *Y, int64_t ldy);
 
 int onemklXsparse_set_matmat_data(matmat_descr_t descr, onemklMatrixView viewA, onemklTranspose
                                   opA, onemklMatrixView viewB, onemklTranspose opB,

--- a/lib/mkl/array.jl
+++ b/lib/mkl/array.jl
@@ -1,4 +1,4 @@
-export oneSparseMatrixCSR
+export oneSparseMatrixCSR, oneSparseMatrixCOO
 
 abstract type oneAbstractSparseArray{Tv, Ti, N} <: AbstractSparseArray{Tv, Ti, N} end
 const oneAbstractSparseVector{Tv, Ti} = oneAbstractSparseArray{Tv, Ti, 1}
@@ -13,10 +13,19 @@ mutable struct oneSparseMatrixCSR{Tv, Ti} <: oneAbstractSparseMatrix{Tv, Ti}
     nnz::Ti
 end
 
-Base.length(A::oneSparseMatrixCSR) = prod(A.dims)
-Base.size(A::oneSparseMatrixCSR) = A.dims
+mutable struct oneSparseMatrixCOO{Tv, Ti} <: oneAbstractSparseMatrix{Tv, Ti}
+    handle::matrix_handle_t
+    rowInd::oneVector{Ti}
+    colInd::oneVector{Ti}
+    nzVal::oneVector{Tv}
+    dims::NTuple{2,Int}
+    nnz::Ti
+end
 
-function Base.size(A::oneSparseMatrixCSR, d::Integer)
+Base.length(A::oneAbstractSparseMatrix) = prod(A.dims)
+Base.size(A::oneAbstractSparseMatrix) = A.dims
+
+function Base.size(A::oneAbstractSparseMatrix, d::Integer)
     if d == 1 || d == 2
         return A.dims[d]
     else
@@ -24,10 +33,11 @@ function Base.size(A::oneSparseMatrixCSR, d::Integer)
     end
 end
 
-SparseArrays.nnz(A::oneSparseMatrixCSR) = A.nnz
-SparseArrays.nonzeros(A::oneSparseMatrixCSR) = A.nzVal
+SparseArrays.nnz(A::oneAbstractSparseMatrix) = A.nnz
+SparseArrays.nonzeros(A::oneAbstractSparseMatrix) = A.nzVal
 
-for (gpu, cpu) in [:oneSparseMatrixCSR => :SparseMatrixCSC]
+for (gpu, cpu) in [:oneSparseMatrixCSR => :SparseMatrixCSC,
+                   :oneSparseMatrixCOO => :SparseMatrixCSC]
     @eval Base.show(io::IOContext, x::$gpu) =
         show(io, $cpu(x))
 

--- a/lib/mkl/wrappers_blas.jl
+++ b/lib/mkl/wrappers_blas.jl
@@ -1,10 +1,10 @@
 ## (GE) general matrix-matrix multiplication batched
 for (fname, elty) in
-        ((:onemklDgemm_batch,:Float64),
-         (:onemklSgemm_batch,:Float32),
-         (:onemklHgemm_batch,:Float16),
-         (:onemklCgemm_batch,:ComplexF32),
-         (:onemklZgemm_batch,:ComplexF64))
+        ((:onemklHgemm_batch, :Float16),
+         (:onemklSgemm_batch, :Float32),
+         (:onemklDgemm_batch, :Float64),
+         (:onemklCgemm_batch, :ComplexF32),
+         (:onemklZgemm_batch, :ComplexF64))
     @eval begin
         function gemm_batched!(transA::Char,
                                transB::Char,
@@ -77,10 +77,10 @@ end
 
 ## (TR) triangular triangular matrix solution batched
 for (fname, elty) in
-        ((:onemklDtrsm_batch,:Float64),
-         (:onemklStrsm_batch,:Float32),
-         (:onemklCtrsm_batch,:ComplexF32),
-         (:onemklZtrsm_batch,:ComplexF64))
+        ((:onemklDtrsm_batch, :Float64),
+         (:onemklStrsm_batch, :Float32),
+         (:onemklCtrsm_batch, :ComplexF32),
+         (:onemklZtrsm_batch, :ComplexF64))
     @eval begin
         function trsm_batched!(side::Char,
                                uplo::Char,
@@ -817,10 +817,10 @@ end
 
 ## iamax
 for (fname, elty) in
-    ((:onemklDiamax,:Float64),
-     (:onemklSiamax,:Float32),
-     (:onemklZiamax,:ComplexF64),
-     (:onemklCiamax,:ComplexF32))
+    ((:onemklDiamax_64,:Float64),
+     (:onemklSiamax_64,:Float32),
+     (:onemklZiamax_64,:ComplexF64),
+     (:onemklCiamax_64,:ComplexF32))
     @eval begin
         function iamax(x::oneStridedArray{$elty})
             n = length(x)
@@ -834,10 +834,10 @@ end
 
 ## iamin
 for (fname, elty) in
-    ((:onemklDiamin,:Float64),
-     (:onemklSiamin,:Float32),
-     (:onemklZiamin,:ComplexF64),
-     (:onemklCiamin,:ComplexF32))
+    ((:onemklDiamin_64,:Float64),
+     (:onemklSiamin_64,:Float32),
+     (:onemklZiamin_64,:ComplexF64),
+     (:onemklCiamin_64,:ComplexF32))
     @eval begin
         function iamin(x::StridedArray{$elty})
             n = length(x)
@@ -1261,11 +1261,11 @@ function dgmm(mode::Char, A::oneStridedMatrix{T}, X::oneStridedVector{T}) where 
 end
 
 for (fname, elty) in
-        ((:onemklSgemm_batch_strided, Float32),
+        ((:onemklHgemm_batch_strided, Float16),
+         (:onemklSgemm_batch_strided, Float32),
          (:onemklDgemm_batch_strided, Float64),
          (:onemklCgemm_batch_strided, ComplexF32),
-         (:onemklZgemm_batch_strided, ComplexF64),
-         (:onemklHgemm_batch_strided, Float16))
+         (:onemklZgemm_batch_strided, ComplexF64))
     @eval begin
         function gemm_strided_batched!(transA::Char,
                                     transB::Char,

--- a/lib/mkl/wrappers_sparse.jl
+++ b/lib/mkl/wrappers_sparse.jl
@@ -144,12 +144,13 @@ for (fname, elty) in ((:onemklSsparse_trsv, :Float32),
         function sparse_trsv!(uplo::Char,
                               trans::Char,
                               diag::Char,
+                              alpha::Number,
                               A::oneSparseMatrixCSR{$elty},
                               x::oneStridedVector{$elty},
                               y::oneStridedVector{$elty})
 
             queue = global_queue(context(y), device(y))
-            $fname(sycl_queue(queue), uplo, trans, diag, A.handle, x, y)
+            $fname(sycl_queue(queue), uplo, trans, diag, alpha, A.handle, x, y)
             y
         end
     end

--- a/lib/mkl/wrappers_sparse.jl
+++ b/lib/mkl/wrappers_sparse.jl
@@ -1,4 +1,4 @@
-function sparse_release_matrix_handle(A::oneSparseMatrixCSR)
+function sparse_release_matrix_handle(A::oneAbstractSparseMatrix)
     queue = global_queue(context(A.nzVal), device(A.nzVal))
     handle_ptr = Ref{matrix_handle_t}(A.handle)
     onemklXsparse_release_matrix_handle(sycl_queue(queue), handle_ptr)
@@ -31,36 +31,73 @@ for (fname, elty, intty) in ((:onemklSsparse_set_csr_data   , :Float32   , :Int3
 
         function SparseMatrixCSC(A::oneSparseMatrixCSR{$elty, $intty})
             handle_ptr = Ref{matrix_handle_t}()
-            At = SparseMatrixCSC(reverse(A.dims)..., Array(A.rowPtr), Array(A.colVal), Array(A.nzVal))
+            At = SparseMatrixCSC(reverse(A.dims)..., Vector(A.rowPtr), Vector(A.colVal), Vector(A.nzVal))
             A_csc = SparseMatrixCSC(At |> transpose)
             return A_csc
         end
     end
 end
 
-for (fname, elty) in ((:onemklSsparse_gemv, :Float32),
-                      (:onemklDsparse_gemv, :Float64),
-                      (:onemklCsparse_gemv, :ComplexF32),
-                      (:onemklZsparse_gemv, :ComplexF64))
+for (fname, elty, intty) in ((:onemklSsparse_set_coo_data   , :Float32   , :Int32),
+                             (:onemklSsparse_set_coo_data_64, :Float32   , :Int64),
+                             (:onemklDsparse_set_coo_data   , :Float64   , :Int32),
+                             (:onemklDsparse_set_coo_data_64, :Float64   , :Int64),
+                             (:onemklCsparse_set_coo_data   , :ComplexF32, :Int32),
+                             (:onemklCsparse_set_coo_data_64, :ComplexF32, :Int64),
+                             (:onemklZsparse_set_coo_data   , :ComplexF64, :Int32),
+                             (:onemklZsparse_set_coo_data_64, :ComplexF64, :Int64))
     @eval begin
-        function sparse_gemv!(trans::Char,
-                              alpha::Number,
-                              A::oneSparseMatrixCSR{$elty},
-                              x::oneStridedVector{$elty},
-                              beta::Number,
-                              y::oneStridedVector{$elty})
+        function oneSparseMatrixCOO(A::SparseMatrixCSC{$elty, $intty})
+            handle_ptr = Ref{matrix_handle_t}()
+            onemklXsparse_init_matrix_handle(handle_ptr)
+            m, n = size(A)
+            row, col, val = findnz(A)
+            rowInd = oneVector{$intty}(row)
+            colInd = oneVector{$intty}(col)
+            nzVal = oneVector{$elty}(val)
+            nnzA = length(val)
+            queue = global_queue(context(nzVal), device(nzVal))
+            $fname(sycl_queue(queue), handle_ptr[], m, n, nnzA, 'O', rowInd, colInd, nzVal)
+            dA = oneSparseMatrixCOO{$elty, $intty}(handle_ptr[], rowInd, colInd, nzVal, (m,n), nnzA)
+            finalizer(sparse_release_matrix_handle, dA)
+            return dA
+        end
 
-            queue = global_queue(context(x), device(x))
-            $fname(sycl_queue(queue), trans, alpha, A.handle, x, beta, y)
-            y
+        function SparseMatrixCSC(A::oneSparseMatrixCOO{$elty, $intty})
+            handle_ptr = Ref{matrix_handle_t}()
+            A = sparse(Vector(A.rowInd), Vector(A.colInd), Vector(A.nzVal), A.dims...)
+            return A
         end
     end
 end
 
-function sparse_optimize_gemv!(trans::Char, A::oneSparseMatrixCSR)
-    queue = global_queue(context(A.nzVal), device(A.nzVal))
-    onemklXsparse_optimize_gemv(sycl_queue(queue), trans, A.handle)
-    return A
+for SparseMatrix in (:oneSparseMatrixCSR, :oneSparseMatrixCOO)
+    for (fname, elty) in ((:onemklSsparse_gemv, :Float32),
+                          (:onemklDsparse_gemv, :Float64),
+                          (:onemklCsparse_gemv, :ComplexF32),
+                          (:onemklZsparse_gemv, :ComplexF64))
+        @eval begin
+            function sparse_gemv!(trans::Char,
+                                  alpha::Number,
+                                  A::$SparseMatrix{$elty},
+                                  x::oneStridedVector{$elty},
+                                  beta::Number,
+                                  y::oneStridedVector{$elty})
+
+                queue = global_queue(context(x), device(x))
+                $fname(sycl_queue(queue), trans, alpha, A.handle, x, beta, y)
+                y
+            end
+        end
+    end
+
+    @eval begin
+        function sparse_optimize_gemv!(trans::Char, A::$SparseMatrix)
+            queue = global_queue(context(A.nzVal), device(A.nzVal))
+            onemklXsparse_optimize_gemv(sycl_queue(queue), trans, A.handle)
+            return A
+        end
+    end
 end
 
 for (fname, elty) in ((:onemklSsparse_gemm, :Float32),
@@ -159,5 +196,47 @@ end
 function sparse_optimize_trsv!(uplo::Char, trans::Char, diag::Char, A::oneSparseMatrixCSR)
     queue = global_queue(context(A.nzVal), device(A.nzVal))
     onemklXsparse_optimize_trsv(sycl_queue(queue), uplo, trans, diag, A.handle)
+    return A
+end
+
+for (fname, elty) in ((:onemklSsparse_trsm, :Float32),
+                      (:onemklDsparse_trsm, :Float64),
+                      (:onemklCsparse_trsm, :ComplexF32),
+                      (:onemklZsparse_trsm, :ComplexF64))
+    @eval begin
+        function sparse_trsm!(uplo::Char,
+                              transA::Char,
+                              transX::Char,
+                              diag::Char,
+                              alpha::Number,
+                              A::oneSparseMatrixCSR{$elty},
+                              X::oneStridedMatrix{$elty},
+                              Y::oneStridedMatrix{$elty})
+
+            mX, nX = size(X)
+            mY, nY = size(Y)
+            (mX != mY) && (transX == 'N') && throw(ArgumentError("X and Y must have the same number of rows."))
+            (nX != nY) && (transX == 'N') && throw(ArgumentError("X and Y must have the same number of columns."))
+            (nX != mY) && (transX != 'N') && throw(ArgumentError("Xᵀ and Y must have the same number of rows."))
+            (mX != nY) && (transX != 'N') && throw(ArgumentError("Xᵀ and Y must have the same number of columns."))
+            nrhs = size(X, 2)
+            ldx = max(1,stride(X,2))
+            ldy = max(1,stride(Y,2))
+            queue = global_queue(context(Y), device(Y))
+            $fname(sycl_queue(queue), 'C', transA, transX, uplo, diag, alpha, A.handle, X, nrhs, ldx, Y, ldy)
+            Y
+        end
+    end
+end
+
+function sparse_optimize_trsm!(uplo::Char, trans::Char, diag::Char, A::oneSparseMatrixCSR)
+    queue = global_queue(context(A.nzVal), device(A.nzVal))
+    onemklXsparse_optimize_trsm(sycl_queue(queue), uplo, trans, diag, A.handle)
+    return A
+end
+
+function sparse_optimize_trsm!(uplo::Char, trans::Char, diag::Char, nrhs::Int, A::oneSparseMatrixCSR)
+    queue = global_queue(context(A.nzVal), device(A.nzVal))
+    onemklXsparse_optimize_trsm_advanced(sycl_queue(queue), 'C', uplo, trans, diag, A.handle, nrhs)
     return A
 end

--- a/lib/support/liboneapi_support.jl
+++ b/lib/support/liboneapi_support.jl
@@ -1212,10 +1212,22 @@ function onemklSiamax(device_queue, n, x, incx, result, base)
                                           result::ZePtr{Int64}, base::onemklIndex)::Cint
 end
 
+function onemklSiamax_64(device_queue, n, x, incx, result, base)
+    @ccall liboneapi_support.onemklSiamax_64(device_queue::syclQueue_t, n::Int64,
+                                             x::ZePtr{Cfloat}, incx::Int64,
+                                             result::ZePtr{Int64}, base::onemklIndex)::Cint
+end
+
 function onemklDiamax(device_queue, n, x, incx, result, base)
     @ccall liboneapi_support.onemklDiamax(device_queue::syclQueue_t, n::Int64,
                                           x::ZePtr{Cdouble}, incx::Int64,
                                           result::ZePtr{Int64}, base::onemklIndex)::Cint
+end
+
+function onemklDiamax_64(device_queue, n, x, incx, result, base)
+    @ccall liboneapi_support.onemklDiamax_64(device_queue::syclQueue_t, n::Int64,
+                                             x::ZePtr{Cdouble}, incx::Int64,
+                                             result::ZePtr{Int64}, base::onemklIndex)::Cint
 end
 
 function onemklCiamax(device_queue, n, x, incx, result, base)
@@ -1224,10 +1236,22 @@ function onemklCiamax(device_queue, n, x, incx, result, base)
                                           result::ZePtr{Int64}, base::onemklIndex)::Cint
 end
 
+function onemklCiamax_64(device_queue, n, x, incx, result, base)
+    @ccall liboneapi_support.onemklCiamax_64(device_queue::syclQueue_t, n::Int64,
+                                             x::ZePtr{ComplexF32}, incx::Int64,
+                                             result::ZePtr{Int64}, base::onemklIndex)::Cint
+end
+
 function onemklZiamax(device_queue, n, x, incx, result, base)
     @ccall liboneapi_support.onemklZiamax(device_queue::syclQueue_t, n::Int64,
                                           x::ZePtr{ComplexF64}, incx::Int64,
                                           result::ZePtr{Int64}, base::onemklIndex)::Cint
+end
+
+function onemklZiamax_64(device_queue, n, x, incx, result, base)
+    @ccall liboneapi_support.onemklZiamax_64(device_queue::syclQueue_t, n::Int64,
+                                             x::ZePtr{ComplexF64}, incx::Int64,
+                                             result::ZePtr{Int64}, base::onemklIndex)::Cint
 end
 
 function onemklSiamin(device_queue, n, x, incx, result, base)
@@ -1236,10 +1260,22 @@ function onemklSiamin(device_queue, n, x, incx, result, base)
                                           result::ZePtr{Int64}, base::onemklIndex)::Cint
 end
 
+function onemklSiamin_64(device_queue, n, x, incx, result, base)
+    @ccall liboneapi_support.onemklSiamin_64(device_queue::syclQueue_t, n::Int64,
+                                             x::ZePtr{Cfloat}, incx::Int64,
+                                             result::ZePtr{Int64}, base::onemklIndex)::Cint
+end
+
 function onemklDiamin(device_queue, n, x, incx, result, base)
     @ccall liboneapi_support.onemklDiamin(device_queue::syclQueue_t, n::Int64,
                                           x::ZePtr{Cdouble}, incx::Int64,
                                           result::ZePtr{Int64}, base::onemklIndex)::Cint
+end
+
+function onemklDiamin_64(device_queue, n, x, incx, result, base)
+    @ccall liboneapi_support.onemklDiamin_64(device_queue::syclQueue_t, n::Int64,
+                                             x::ZePtr{Cdouble}, incx::Int64,
+                                             result::ZePtr{Int64}, base::onemklIndex)::Cint
 end
 
 function onemklCiamin(device_queue, n, x, incx, result, base)
@@ -1248,10 +1284,22 @@ function onemklCiamin(device_queue, n, x, incx, result, base)
                                           result::ZePtr{Int64}, base::onemklIndex)::Cint
 end
 
+function onemklCiamin_64(device_queue, n, x, incx, result, base)
+    @ccall liboneapi_support.onemklCiamin_64(device_queue::syclQueue_t, n::Int64,
+                                             x::ZePtr{ComplexF32}, incx::Int64,
+                                             result::ZePtr{Int64}, base::onemklIndex)::Cint
+end
+
 function onemklZiamin(device_queue, n, x, incx, result, base)
     @ccall liboneapi_support.onemklZiamin(device_queue::syclQueue_t, n::Int64,
                                           x::ZePtr{ComplexF64}, incx::Int64,
                                           result::ZePtr{Int64}, base::onemklIndex)::Cint
+end
+
+function onemklZiamin_64(device_queue, n, x, incx, result, base)
+    @ccall liboneapi_support.onemklZiamin_64(device_queue::syclQueue_t, n::Int64,
+                                             x::ZePtr{ComplexF64}, incx::Int64,
+                                             result::ZePtr{Int64}, base::onemklIndex)::Cint
 end
 
 function onemklSasum(device_queue, n, x, incx, result)
@@ -2721,6 +2769,148 @@ function onemklSgesvd(device_queue, jobu, jobvt, m, n, a, lda, s, u, ldu, vt, ld
                                           u::ZePtr{Float32}, ldu::Int64, vt::ZePtr{Float32},
                                           ldvt::Int64, scratchpad::ZePtr{Float32},
                                           scratchpad_size::Int64)::Cint
+end
+
+function onemklSgesvda_batch_strided_scratchpad_size(device_queue, m, n, lda, stride_a,
+                                                     stride_s, ldu, stride_u, ldvt,
+                                                     stride_vt, batch_size)
+    @ccall liboneapi_support.onemklSgesvda_batch_strided_scratchpad_size(device_queue::syclQueue_t,
+                                                                         m::Int64, n::Int64,
+                                                                         lda::Int64,
+                                                                         stride_a::Int64,
+                                                                         stride_s::Int64,
+                                                                         ldu::Int64,
+                                                                         stride_u::Int64,
+                                                                         ldvt::Int64,
+                                                                         stride_vt::Int64,
+                                                                         batch_size::Int64)::Int64
+end
+
+function onemklDgesvda_batch_strided_scratchpad_size(device_queue, m, n, lda, stride_a,
+                                                     stride_s, ldu, stride_u, ldvt,
+                                                     stride_vt, batch_size)
+    @ccall liboneapi_support.onemklDgesvda_batch_strided_scratchpad_size(device_queue::syclQueue_t,
+                                                                         m::Int64, n::Int64,
+                                                                         lda::Int64,
+                                                                         stride_a::Int64,
+                                                                         stride_s::Int64,
+                                                                         ldu::Int64,
+                                                                         stride_u::Int64,
+                                                                         ldvt::Int64,
+                                                                         stride_vt::Int64,
+                                                                         batch_size::Int64)::Int64
+end
+
+function onemklCgesvda_batch_strided_scratchpad_size(device_queue, m, n, lda, stride_a,
+                                                     stride_s, ldu, stride_u, ldvt,
+                                                     stride_vt, batch_size)
+    @ccall liboneapi_support.onemklCgesvda_batch_strided_scratchpad_size(device_queue::syclQueue_t,
+                                                                         m::Int64, n::Int64,
+                                                                         lda::Int64,
+                                                                         stride_a::Int64,
+                                                                         stride_s::Int64,
+                                                                         ldu::Int64,
+                                                                         stride_u::Int64,
+                                                                         ldvt::Int64,
+                                                                         stride_vt::Int64,
+                                                                         batch_size::Int64)::Int64
+end
+
+function onemklZgesvda_batch_strided_scratchpad_size(device_queue, m, n, lda, stride_a,
+                                                     stride_s, ldu, stride_u, ldvt,
+                                                     stride_vt, batch_size)
+    @ccall liboneapi_support.onemklZgesvda_batch_strided_scratchpad_size(device_queue::syclQueue_t,
+                                                                         m::Int64, n::Int64,
+                                                                         lda::Int64,
+                                                                         stride_a::Int64,
+                                                                         stride_s::Int64,
+                                                                         ldu::Int64,
+                                                                         stride_u::Int64,
+                                                                         ldvt::Int64,
+                                                                         stride_vt::Int64,
+                                                                         batch_size::Int64)::Int64
+end
+
+function onemklCgesvda_batch_strided(device_queue, iparm, irank, m, n, a, lda, stride_a, s,
+                                     stride_s, u, ldu, stride_u, vt, ldvt, stride_vt,
+                                     tolerance, residual, batch_size, scratchpad,
+                                     scratchpad_size)
+    @ccall liboneapi_support.onemklCgesvda_batch_strided(device_queue::syclQueue_t,
+                                                         iparm::Ptr{Int64},
+                                                         irank::Ptr{Int64}, m::Int64,
+                                                         n::Int64, a::Ptr{ComplexF32},
+                                                         lda::Int64, stride_a::Int64,
+                                                         s::Ptr{Cfloat}, stride_s::Int64,
+                                                         u::Ptr{ComplexF32}, ldu::Int64,
+                                                         stride_u::Int64,
+                                                         vt::Ptr{ComplexF32}, ldvt::Int64,
+                                                         stride_vt::Int64,
+                                                         tolerance::Ptr{Cfloat},
+                                                         residual::Ptr{Cfloat},
+                                                         batch_size::Int64,
+                                                         scratchpad::Ptr{ComplexF32},
+                                                         scratchpad_size::Int64)::Cint
+end
+
+function onemklDgesvda_batch_strided(device_queue, iparm, irank, m, n, a, lda, stride_a, s,
+                                     stride_s, u, ldu, stride_u, vt, ldvt, stride_vt,
+                                     tolerance, residual, batch_size, scratchpad,
+                                     scratchpad_size)
+    @ccall liboneapi_support.onemklDgesvda_batch_strided(device_queue::syclQueue_t,
+                                                         iparm::Ptr{Int64},
+                                                         irank::Ptr{Int64}, m::Int64,
+                                                         n::Int64, a::Ptr{Cdouble},
+                                                         lda::Int64, stride_a::Int64,
+                                                         s::Ptr{Cdouble}, stride_s::Int64,
+                                                         u::Ptr{Cdouble}, ldu::Int64,
+                                                         stride_u::Int64, vt::Ptr{Cdouble},
+                                                         ldvt::Int64, stride_vt::Int64,
+                                                         tolerance::Ptr{Cdouble},
+                                                         residual::Ptr{Cdouble},
+                                                         batch_size::Int64,
+                                                         scratchpad::Ptr{Cdouble},
+                                                         scratchpad_size::Int64)::Cint
+end
+
+function onemklSgesvda_batch_strided(device_queue, iparm, irank, m, n, a, lda, stride_a, s,
+                                     stride_s, u, ldu, stride_u, vt, ldvt, stride_vt,
+                                     tolerance, residual, batch_size, scratchpad,
+                                     scratchpad_size)
+    @ccall liboneapi_support.onemklSgesvda_batch_strided(device_queue::syclQueue_t,
+                                                         iparm::Ptr{Int64},
+                                                         irank::Ptr{Int64}, m::Int64,
+                                                         n::Int64, a::Ptr{Cfloat},
+                                                         lda::Int64, stride_a::Int64,
+                                                         s::Ptr{Cfloat}, stride_s::Int64,
+                                                         u::Ptr{Cfloat}, ldu::Int64,
+                                                         stride_u::Int64, vt::Ptr{Cfloat},
+                                                         ldvt::Int64, stride_vt::Int64,
+                                                         tolerance::Ptr{Cfloat},
+                                                         residual::Ptr{Cfloat},
+                                                         batch_size::Int64,
+                                                         scratchpad::Ptr{Cfloat},
+                                                         scratchpad_size::Int64)::Cint
+end
+
+function onemklZgesvda_batch_strided(device_queue, iparm, irank, m, n, a, lda, stride_a, s,
+                                     stride_s, u, ldu, stride_u, vt, ldvt, stride_vt,
+                                     tolerance, residual, batch_size, scratchpad,
+                                     scratchpad_size)
+    @ccall liboneapi_support.onemklZgesvda_batch_strided(device_queue::syclQueue_t,
+                                                         iparm::Ptr{Int64},
+                                                         irank::Ptr{Int64}, m::Int64,
+                                                         n::Int64, a::Ptr{ComplexF32},
+                                                         lda::Int64, stride_a::Int64,
+                                                         s::Ptr{Cdouble}, stride_s::Int64,
+                                                         u::Ptr{ComplexF32}, ldu::Int64,
+                                                         stride_u::Int64,
+                                                         vt::Ptr{ComplexF32}, ldvt::Int64,
+                                                         stride_vt::Int64,
+                                                         tolerance::Ptr{Cdouble},
+                                                         residual::Ptr{Cdouble},
+                                                         batch_size::Int64,
+                                                         scratchpad::Ptr{ComplexF32},
+                                                         scratchpad_size::Int64)::Cint
 end
 
 function onemklSgetrf_scratchpad_size(device_queue, m, n, lda)
@@ -4789,6 +4979,166 @@ function onemklZungqr_batch(device_queue, m, n, k, a, lda, tau, group_count, gro
                                                 scratchpad_size::Int64)::Cint
 end
 
+function onemklSormqr_batch(device_queue, side, trans, m, n, k, a, lda, tau, c, ldc,
+                            group_count, group_sizes, scratchpad, scratchpad_size)
+    @ccall liboneapi_support.onemklSormqr_batch(device_queue::syclQueue_t,
+                                                side::Ptr{onemklSide},
+                                                trans::Ptr{onemklTranspose}, m::Ptr{Int64},
+                                                n::Ptr{Int64}, k::Ptr{Int64},
+                                                a::Ptr{Ptr{Cfloat}}, lda::Ptr{Int64},
+                                                tau::Ptr{Ptr{Cfloat}}, c::Ptr{Ptr{Cfloat}},
+                                                ldc::Ptr{Int64}, group_count::Int64,
+                                                group_sizes::Ptr{Int64},
+                                                scratchpad::Ptr{Cfloat},
+                                                scratchpad_size::Int64)::Cint
+end
+
+function onemklDormqr_batch(device_queue, side, trans, m, n, k, a, lda, tau, c, ldc,
+                            group_count, group_sizes, scratchpad, scratchpad_size)
+    @ccall liboneapi_support.onemklDormqr_batch(device_queue::syclQueue_t,
+                                                side::Ptr{onemklSide},
+                                                trans::Ptr{onemklTranspose}, m::Ptr{Int64},
+                                                n::Ptr{Int64}, k::Ptr{Int64},
+                                                a::Ptr{Ptr{Cdouble}}, lda::Ptr{Int64},
+                                                tau::Ptr{Ptr{Cdouble}},
+                                                c::Ptr{Ptr{Cdouble}}, ldc::Ptr{Int64},
+                                                group_count::Int64, group_sizes::Ptr{Int64},
+                                                scratchpad::Ptr{Cdouble},
+                                                scratchpad_size::Int64)::Cint
+end
+
+function onemklCunmqr_batch(device_queue, side, trans, m, n, k, a, lda, tau, c, ldc,
+                            group_count, group_sizes, scratchpad, scratchpad_size)
+    @ccall liboneapi_support.onemklCunmqr_batch(device_queue::syclQueue_t,
+                                                side::Ptr{onemklSide},
+                                                trans::Ptr{onemklTranspose}, m::Ptr{Int64},
+                                                n::Ptr{Int64}, k::Ptr{Int64},
+                                                a::Ptr{Ptr{ComplexF32}}, lda::Ptr{Int64},
+                                                tau::Ptr{Ptr{ComplexF32}},
+                                                c::Ptr{Ptr{ComplexF32}}, ldc::Ptr{Int64},
+                                                group_count::Int64, group_sizes::Ptr{Int64},
+                                                scratchpad::Ptr{ComplexF32},
+                                                scratchpad_size::Int64)::Cint
+end
+
+function onemklZunmqr_batch(device_queue, side, trans, m, n, k, a, lda, tau, c, ldc,
+                            group_count, group_sizes, scratchpad, scratchpad_size)
+    @ccall liboneapi_support.onemklZunmqr_batch(device_queue::syclQueue_t,
+                                                side::Ptr{onemklSide},
+                                                trans::Ptr{onemklTranspose}, m::Ptr{Int64},
+                                                n::Ptr{Int64}, k::Ptr{Int64},
+                                                a::Ptr{Ptr{ComplexF32}}, lda::Ptr{Int64},
+                                                tau::Ptr{Ptr{ComplexF32}},
+                                                c::Ptr{Ptr{ComplexF32}}, ldc::Ptr{Int64},
+                                                group_count::Int64, group_sizes::Ptr{Int64},
+                                                scratchpad::Ptr{ComplexF32},
+                                                scratchpad_size::Int64)::Cint
+end
+
+function onemklStrtrs_batch(device_queue, uplo, trans, diag, n, nrhs, a, lda, b, ldb,
+                            group_count, group_sizes, scratchpad, scratchpad_size)
+    @ccall liboneapi_support.onemklStrtrs_batch(device_queue::syclQueue_t,
+                                                uplo::Ptr{onemklUplo},
+                                                trans::Ptr{onemklTranspose},
+                                                diag::Ptr{onemklDiag}, n::Ptr{Int64},
+                                                nrhs::Ptr{Int64}, a::Ptr{Ptr{Cfloat}},
+                                                lda::Ptr{Int64}, b::Ptr{Ptr{Cfloat}},
+                                                ldb::Ptr{Int64}, group_count::Int64,
+                                                group_sizes::Ptr{Int64},
+                                                scratchpad::Ptr{Cfloat},
+                                                scratchpad_size::Int64)::Cint
+end
+
+function onemklDtrtrs_batch(device_queue, uplo, trans, diag, n, nrhs, a, lda, b, ldb,
+                            group_count, group_sizes, scratchpad, scratchpad_size)
+    @ccall liboneapi_support.onemklDtrtrs_batch(device_queue::syclQueue_t,
+                                                uplo::Ptr{onemklUplo},
+                                                trans::Ptr{onemklTranspose},
+                                                diag::Ptr{onemklDiag}, n::Ptr{Int64},
+                                                nrhs::Ptr{Int64}, a::Ptr{Ptr{Cdouble}},
+                                                lda::Ptr{Int64}, b::Ptr{Ptr{Cdouble}},
+                                                ldb::Ptr{Int64}, group_count::Int64,
+                                                group_sizes::Ptr{Int64},
+                                                scratchpad::Ptr{Cdouble},
+                                                scratchpad_size::Int64)::Cint
+end
+
+function onemklCtrtrs_batch(device_queue, uplo, trans, diag, n, nrhs, a, lda, b, ldb,
+                            group_count, group_sizes, scratchpad, scratchpad_size)
+    @ccall liboneapi_support.onemklCtrtrs_batch(device_queue::syclQueue_t,
+                                                uplo::Ptr{onemklUplo},
+                                                trans::Ptr{onemklTranspose},
+                                                diag::Ptr{onemklDiag}, n::Ptr{Int64},
+                                                nrhs::Ptr{Int64}, a::Ptr{Ptr{ComplexF32}},
+                                                lda::Ptr{Int64}, b::Ptr{Ptr{ComplexF32}},
+                                                ldb::Ptr{Int64}, group_count::Int64,
+                                                group_sizes::Ptr{Int64},
+                                                scratchpad::Ptr{ComplexF32},
+                                                scratchpad_size::Int64)::Cint
+end
+
+function onemklZtrtrs_batch(device_queue, uplo, trans, diag, n, nrhs, a, lda, b, ldb,
+                            group_count, group_sizes, scratchpad, scratchpad_size)
+    @ccall liboneapi_support.onemklZtrtrs_batch(device_queue::syclQueue_t,
+                                                uplo::Ptr{onemklUplo},
+                                                trans::Ptr{onemklTranspose},
+                                                diag::Ptr{onemklDiag}, n::Ptr{Int64},
+                                                nrhs::Ptr{Int64}, a::Ptr{Ptr{ComplexF32}},
+                                                lda::Ptr{Int64}, b::Ptr{Ptr{ComplexF32}},
+                                                ldb::Ptr{Int64}, group_count::Int64,
+                                                group_sizes::Ptr{Int64},
+                                                scratchpad::Ptr{ComplexF32},
+                                                scratchpad_size::Int64)::Cint
+end
+
+function onemklSgels_batch(device_queue, trans, m, n, nrhs, a, lda, b, ldb, group_count,
+                           group_sizes, scratchpad, scratchpad_size)
+    @ccall liboneapi_support.onemklSgels_batch(device_queue::syclQueue_t,
+                                               trans::Ptr{onemklTranspose}, m::Ptr{Int64},
+                                               n::Ptr{Int64}, nrhs::Ptr{Int64},
+                                               a::Ptr{Ptr{Cfloat}}, lda::Ptr{Int64},
+                                               b::Ptr{Ptr{Cfloat}}, ldb::Ptr{Int64},
+                                               group_count::Int64, group_sizes::Ptr{Int64},
+                                               scratchpad::Ptr{Cfloat},
+                                               scratchpad_size::Int64)::Cint
+end
+
+function onemklDgels_batch(device_queue, trans, m, n, nrhs, a, lda, b, ldb, group_count,
+                           group_sizes, scratchpad, scratchpad_size)
+    @ccall liboneapi_support.onemklDgels_batch(device_queue::syclQueue_t,
+                                               trans::Ptr{onemklTranspose}, m::Ptr{Int64},
+                                               n::Ptr{Int64}, nrhs::Ptr{Int64},
+                                               a::Ptr{Ptr{Cdouble}}, lda::Ptr{Int64},
+                                               b::Ptr{Ptr{Cdouble}}, ldb::Ptr{Int64},
+                                               group_count::Int64, group_sizes::Ptr{Int64},
+                                               scratchpad::Ptr{Cdouble},
+                                               scratchpad_size::Int64)::Cint
+end
+
+function onemklCgels_batch(device_queue, trans, m, n, nrhs, a, lda, b, ldb, group_count,
+                           group_sizes, scratchpad, scratchpad_size)
+    @ccall liboneapi_support.onemklCgels_batch(device_queue::syclQueue_t,
+                                               trans::Ptr{onemklTranspose}, m::Ptr{Int64},
+                                               n::Ptr{Int64}, nrhs::Ptr{Int64},
+                                               a::Ptr{Ptr{ComplexF32}}, lda::Ptr{Int64},
+                                               b::Ptr{Ptr{ComplexF32}}, ldb::Ptr{Int64},
+                                               group_count::Int64, group_sizes::Ptr{Int64},
+                                               scratchpad::Ptr{ComplexF32},
+                                               scratchpad_size::Int64)::Cint
+end
+
+function onemklZgels_batch(device_queue, trans, m, n, nrhs, a, lda, b, ldb, group_count,
+                           group_sizes, scratchpad, scratchpad_size)
+    @ccall liboneapi_support.onemklZgels_batch(device_queue::syclQueue_t,
+                                               trans::Ptr{onemklTranspose}, m::Ptr{Int64},
+                                               n::Ptr{Int64}, nrhs::Ptr{Int64},
+                                               a::Ptr{Ptr{ComplexF32}}, lda::Ptr{Int64},
+                                               b::Ptr{Ptr{ComplexF32}}, ldb::Ptr{Int64},
+                                               group_count::Int64, group_sizes::Ptr{Int64},
+                                               scratchpad::Ptr{ComplexF32},
+                                               scratchpad_size::Int64)::Cint
+end
+
 function onemklSpotrf_batch_scratchpad_size(device_queue, uplo, n, lda, group_count,
                                             group_sizes)
     @ccall liboneapi_support.onemklSpotrf_batch_scratchpad_size(device_queue::syclQueue_t,
@@ -5071,6 +5421,166 @@ function onemklZungqr_batch_scratchpad_size(device_queue, m, n, k, lda, group_co
                                                                 lda::Ptr{Int64},
                                                                 group_count::Int64,
                                                                 group_sizes::Ptr{Int64})::Int64
+end
+
+function onemklSormqr_batch_scratchpad_size(device_queue, side, trans, m, n, k, lda, ldc,
+                                            group_count, group_sizes)
+    @ccall liboneapi_support.onemklSormqr_batch_scratchpad_size(device_queue::syclQueue_t,
+                                                                side::Ptr{onemklSide},
+                                                                trans::Ptr{onemklTranspose},
+                                                                m::Ptr{Int64},
+                                                                n::Ptr{Int64},
+                                                                k::Ptr{Int64},
+                                                                lda::Ptr{Int64},
+                                                                ldc::Ptr{Int64},
+                                                                group_count::Int64,
+                                                                group_sizes::Ptr{Int64})::Int64
+end
+
+function onemklDormqr_batch_scratchpad_size(device_queue, side, trans, m, n, k, lda, ldc,
+                                            group_count, group_sizes)
+    @ccall liboneapi_support.onemklDormqr_batch_scratchpad_size(device_queue::syclQueue_t,
+                                                                side::Ptr{onemklSide},
+                                                                trans::Ptr{onemklTranspose},
+                                                                m::Ptr{Int64},
+                                                                n::Ptr{Int64},
+                                                                k::Ptr{Int64},
+                                                                lda::Ptr{Int64},
+                                                                ldc::Ptr{Int64},
+                                                                group_count::Int64,
+                                                                group_sizes::Ptr{Int64})::Int64
+end
+
+function onemklCunmqr_batch_scratchpad_size(device_queue, side, trans, m, n, k, lda, ldc,
+                                            group_count, group_sizes)
+    @ccall liboneapi_support.onemklCunmqr_batch_scratchpad_size(device_queue::syclQueue_t,
+                                                                side::Ptr{onemklSide},
+                                                                trans::Ptr{onemklTranspose},
+                                                                m::Ptr{Int64},
+                                                                n::Ptr{Int64},
+                                                                k::Ptr{Int64},
+                                                                lda::Ptr{Int64},
+                                                                ldc::Ptr{Int64},
+                                                                group_count::Int64,
+                                                                group_sizes::Ptr{Int64})::Int64
+end
+
+function onemklZunmqr_batch_scratchpad_size(device_queue, side, trans, m, n, k, lda, ldc,
+                                            group_count, group_sizes)
+    @ccall liboneapi_support.onemklZunmqr_batch_scratchpad_size(device_queue::syclQueue_t,
+                                                                side::Ptr{onemklSide},
+                                                                trans::Ptr{onemklTranspose},
+                                                                m::Ptr{Int64},
+                                                                n::Ptr{Int64},
+                                                                k::Ptr{Int64},
+                                                                lda::Ptr{Int64},
+                                                                ldc::Ptr{Int64},
+                                                                group_count::Int64,
+                                                                group_sizes::Ptr{Int64})::Int64
+end
+
+function onemklStrtrs_batch_scratchpad_size(device_queue, uplo, trans, diag, n, nrhs, lda,
+                                            ldb, group_count, group_sizes)
+    @ccall liboneapi_support.onemklStrtrs_batch_scratchpad_size(device_queue::syclQueue_t,
+                                                                uplo::Ptr{onemklUplo},
+                                                                trans::Ptr{onemklTranspose},
+                                                                diag::Ptr{onemklDiag},
+                                                                n::Ptr{Int64},
+                                                                nrhs::Ptr{Int64},
+                                                                lda::Ptr{Int64},
+                                                                ldb::Ptr{Int64},
+                                                                group_count::Int64,
+                                                                group_sizes::Ptr{Int64})::Int64
+end
+
+function onemklDtrtrs_batch_scratchpad_size(device_queue, uplo, trans, diag, n, nrhs, lda,
+                                            ldb, group_count, group_sizes)
+    @ccall liboneapi_support.onemklDtrtrs_batch_scratchpad_size(device_queue::syclQueue_t,
+                                                                uplo::Ptr{onemklUplo},
+                                                                trans::Ptr{onemklTranspose},
+                                                                diag::Ptr{onemklDiag},
+                                                                n::Ptr{Int64},
+                                                                nrhs::Ptr{Int64},
+                                                                lda::Ptr{Int64},
+                                                                ldb::Ptr{Int64},
+                                                                group_count::Int64,
+                                                                group_sizes::Ptr{Int64})::Int64
+end
+
+function onemklCtrtrs_batch_scratchpad_size(device_queue, uplo, trans, diag, n, nrhs, lda,
+                                            ldb, group_count, group_sizes)
+    @ccall liboneapi_support.onemklCtrtrs_batch_scratchpad_size(device_queue::syclQueue_t,
+                                                                uplo::Ptr{onemklUplo},
+                                                                trans::Ptr{onemklTranspose},
+                                                                diag::Ptr{onemklDiag},
+                                                                n::Ptr{Int64},
+                                                                nrhs::Ptr{Int64},
+                                                                lda::Ptr{Int64},
+                                                                ldb::Ptr{Int64},
+                                                                group_count::Int64,
+                                                                group_sizes::Ptr{Int64})::Int64
+end
+
+function onemklZtrtrs_batch_scratchpad_size(device_queue, uplo, trans, diag, n, nrhs, lda,
+                                            ldb, group_count, group_sizes)
+    @ccall liboneapi_support.onemklZtrtrs_batch_scratchpad_size(device_queue::syclQueue_t,
+                                                                uplo::Ptr{onemklUplo},
+                                                                trans::Ptr{onemklTranspose},
+                                                                diag::Ptr{onemklDiag},
+                                                                n::Ptr{Int64},
+                                                                nrhs::Ptr{Int64},
+                                                                lda::Ptr{Int64},
+                                                                ldb::Ptr{Int64},
+                                                                group_count::Int64,
+                                                                group_sizes::Ptr{Int64})::Int64
+end
+
+function onemklSgels_batch_scratchpad_size(device_queue, trans, m, n, nrhs, lda, ldb,
+                                           group_count, group_sizes)
+    @ccall liboneapi_support.onemklSgels_batch_scratchpad_size(device_queue::syclQueue_t,
+                                                               trans::Ptr{onemklTranspose},
+                                                               m::Ptr{Int64}, n::Ptr{Int64},
+                                                               nrhs::Ptr{Int64},
+                                                               lda::Ptr{Int64},
+                                                               ldb::Ptr{Int64},
+                                                               group_count::Int64,
+                                                               group_sizes::Ptr{Int64})::Int64
+end
+
+function onemklDgels_batch_scratchpad_size(device_queue, trans, m, n, nrhs, lda, ldb,
+                                           group_count, group_sizes)
+    @ccall liboneapi_support.onemklDgels_batch_scratchpad_size(device_queue::syclQueue_t,
+                                                               trans::Ptr{onemklTranspose},
+                                                               m::Ptr{Int64}, n::Ptr{Int64},
+                                                               nrhs::Ptr{Int64},
+                                                               lda::Ptr{Int64},
+                                                               ldb::Ptr{Int64},
+                                                               group_count::Int64,
+                                                               group_sizes::Ptr{Int64})::Int64
+end
+
+function onemklCgels_batch_scratchpad_size(device_queue, trans, m, n, nrhs, lda, ldb,
+                                           group_count, group_sizes)
+    @ccall liboneapi_support.onemklCgels_batch_scratchpad_size(device_queue::syclQueue_t,
+                                                               trans::Ptr{onemklTranspose},
+                                                               m::Ptr{Int64}, n::Ptr{Int64},
+                                                               nrhs::Ptr{Int64},
+                                                               lda::Ptr{Int64},
+                                                               ldb::Ptr{Int64},
+                                                               group_count::Int64,
+                                                               group_sizes::Ptr{Int64})::Int64
+end
+
+function onemklZgels_batch_scratchpad_size(device_queue, trans, m, n, nrhs, lda, ldb,
+                                           group_count, group_sizes)
+    @ccall liboneapi_support.onemklZgels_batch_scratchpad_size(device_queue::syclQueue_t,
+                                                               trans::Ptr{onemklTranspose},
+                                                               m::Ptr{Int64}, n::Ptr{Int64},
+                                                               nrhs::Ptr{Int64},
+                                                               lda::Ptr{Int64},
+                                                               ldb::Ptr{Int64},
+                                                               group_count::Int64,
+                                                               group_sizes::Ptr{Int64})::Int64
 end
 
 function onemklSpotrf_batch_strided(device_queue, uplo, n, a, lda, stride_a, batch_size,
@@ -5718,6 +6228,94 @@ function onemklZsparse_set_csr_data_64(device_queue, spMat, nrows, ncols, index,
                                                            values::ZePtr{ComplexF64})::Cint
 end
 
+function onemklSsparse_set_coo_data(device_queue, spMat, nrows, ncols, nnz, index, row_ind,
+                                    col_ind, values)
+    @ccall liboneapi_support.onemklSsparse_set_coo_data(device_queue::syclQueue_t,
+                                                        spMat::matrix_handle_t,
+                                                        nrows::Int32, ncols::Int32,
+                                                        nnz::Int32, index::onemklIndex,
+                                                        row_ind::ZePtr{Int32},
+                                                        col_ind::ZePtr{Int32},
+                                                        values::ZePtr{Cfloat})::Cint
+end
+
+function onemklSsparse_set_coo_data_64(device_queue, spMat, nrows, ncols, nnz, index,
+                                       row_ind, col_ind, values)
+    @ccall liboneapi_support.onemklSsparse_set_coo_data_64(device_queue::syclQueue_t,
+                                                           spMat::matrix_handle_t,
+                                                           nrows::Int64, ncols::Int64,
+                                                           nnz::Int64, index::onemklIndex,
+                                                           row_ind::ZePtr{Int64},
+                                                           col_ind::ZePtr{Int64},
+                                                           values::ZePtr{Cfloat})::Cint
+end
+
+function onemklDsparse_set_coo_data(device_queue, spMat, nrows, ncols, nnz, index, row_ind,
+                                    col_ind, values)
+    @ccall liboneapi_support.onemklDsparse_set_coo_data(device_queue::syclQueue_t,
+                                                        spMat::matrix_handle_t,
+                                                        nrows::Int32, ncols::Int32,
+                                                        nnz::Int32, index::onemklIndex,
+                                                        row_ind::ZePtr{Int32},
+                                                        col_ind::ZePtr{Int32},
+                                                        values::ZePtr{Cdouble})::Cint
+end
+
+function onemklDsparse_set_coo_data_64(device_queue, spMat, nrows, ncols, nnz, index,
+                                       row_ind, col_ind, values)
+    @ccall liboneapi_support.onemklDsparse_set_coo_data_64(device_queue::syclQueue_t,
+                                                           spMat::matrix_handle_t,
+                                                           nrows::Int64, ncols::Int64,
+                                                           nnz::Int64, index::onemklIndex,
+                                                           row_ind::ZePtr{Int64},
+                                                           col_ind::ZePtr{Int64},
+                                                           values::ZePtr{Cdouble})::Cint
+end
+
+function onemklCsparse_set_coo_data(device_queue, spMat, nrows, ncols, nnz, index, row_ind,
+                                    col_ind, values)
+    @ccall liboneapi_support.onemklCsparse_set_coo_data(device_queue::syclQueue_t,
+                                                        spMat::matrix_handle_t,
+                                                        nrows::Int32, ncols::Int32,
+                                                        nnz::Int32, index::onemklIndex,
+                                                        row_ind::ZePtr{Int32},
+                                                        col_ind::ZePtr{Int32},
+                                                        values::ZePtr{ComplexF32})::Cint
+end
+
+function onemklCsparse_set_coo_data_64(device_queue, spMat, nrows, ncols, nnz, index,
+                                       row_ind, col_ind, values)
+    @ccall liboneapi_support.onemklCsparse_set_coo_data_64(device_queue::syclQueue_t,
+                                                           spMat::matrix_handle_t,
+                                                           nrows::Int64, ncols::Int64,
+                                                           nnz::Int64, index::onemklIndex,
+                                                           row_ind::ZePtr{Int64},
+                                                           col_ind::ZePtr{Int64},
+                                                           values::ZePtr{ComplexF32})::Cint
+end
+
+function onemklZsparse_set_coo_data(device_queue, spMat, nrows, ncols, nnz, index, row_ind,
+                                    col_ind, values)
+    @ccall liboneapi_support.onemklZsparse_set_coo_data(device_queue::syclQueue_t,
+                                                        spMat::matrix_handle_t,
+                                                        nrows::Int32, ncols::Int32,
+                                                        nnz::Int32, index::onemklIndex,
+                                                        row_ind::ZePtr{Int32},
+                                                        col_ind::ZePtr{Int32},
+                                                        values::ZePtr{ComplexF64})::Cint
+end
+
+function onemklZsparse_set_coo_data_64(device_queue, spMat, nrows, ncols, nnz, index,
+                                       row_ind, col_ind, values)
+    @ccall liboneapi_support.onemklZsparse_set_coo_data_64(device_queue::syclQueue_t,
+                                                           spMat::matrix_handle_t,
+                                                           nrows::Int64, ncols::Int64,
+                                                           nnz::Int64, index::onemklIndex,
+                                                           row_ind::ZePtr{Int64},
+                                                           col_ind::ZePtr{Int64},
+                                                           values::ZePtr{ComplexF64})::Cint
+end
+
 function onemklXsparse_init_matmat_descr(p_desc)
     @ccall liboneapi_support.onemklXsparse_init_matmat_descr(p_desc::Ptr{matmat_descr_t})::Cint
 end
@@ -5786,6 +6384,25 @@ function onemklXsparse_optimize_trsv(device_queue, uplo_val, opA, diag_val, A)
                                                          opA::onemklTranspose,
                                                          diag_val::onemklDiag,
                                                          A::matrix_handle_t)::Cint
+end
+
+function onemklXsparse_optimize_trsm(device_queue, uplo_val, opA, diag_val, A)
+    @ccall liboneapi_support.onemklXsparse_optimize_trsm(device_queue::syclQueue_t,
+                                                         uplo_val::onemklUplo,
+                                                         opA::onemklTranspose,
+                                                         diag_val::onemklDiag,
+                                                         A::matrix_handle_t)::Cint
+end
+
+function onemklXsparse_optimize_trsm_advanced(device_queue, layout_val, uplo_val, opA,
+                                              diag_val, A, columns)
+    @ccall liboneapi_support.onemklXsparse_optimize_trsm_advanced(device_queue::syclQueue_t,
+                                                                  layout_val::onemklLayout,
+                                                                  uplo_val::onemklUplo,
+                                                                  opA::onemklTranspose,
+                                                                  diag_val::onemklDiag,
+                                                                  A::matrix_handle_t,
+                                                                  columns::Int64)::Cint
 end
 
 function onemklSsparse_gemv(device_queue, opA, alpha, A, x, beta, y)
@@ -5919,32 +6536,36 @@ function onemklZsparse_trmv(device_queue, uplo_val, opA, diag_val, alpha, A, x, 
                                                 y::ZePtr{ComplexF64})::Cint
 end
 
-function onemklSsparse_trsv(device_queue, uplo_val, opA, diag_val, A, x, y)
+function onemklSsparse_trsv(device_queue, uplo_val, opA, diag_val, alpha, A, x, y)
     @ccall liboneapi_support.onemklSsparse_trsv(device_queue::syclQueue_t,
                                                 uplo_val::onemklUplo, opA::onemklTranspose,
-                                                diag_val::onemklDiag, A::matrix_handle_t,
-                                                x::ZePtr{Cfloat}, y::ZePtr{Cfloat})::Cint
+                                                diag_val::onemklDiag, alpha::Ref{Cfloat},
+                                                A::matrix_handle_t, x::ZePtr{Cfloat},
+                                                y::ZePtr{Cfloat})::Cint
 end
 
-function onemklDsparse_trsv(device_queue, uplo_val, opA, diag_val, A, x, y)
+function onemklDsparse_trsv(device_queue, uplo_val, opA, diag_val, alpha, A, x, y)
     @ccall liboneapi_support.onemklDsparse_trsv(device_queue::syclQueue_t,
                                                 uplo_val::onemklUplo, opA::onemklTranspose,
-                                                diag_val::onemklDiag, A::matrix_handle_t,
-                                                x::ZePtr{Cdouble}, y::ZePtr{Cdouble})::Cint
+                                                diag_val::onemklDiag, alpha::Ref{Cdouble},
+                                                A::matrix_handle_t, x::ZePtr{Cdouble},
+                                                y::ZePtr{Cdouble})::Cint
 end
 
-function onemklCsparse_trsv(device_queue, uplo_val, opA, diag_val, A, x, y)
+function onemklCsparse_trsv(device_queue, uplo_val, opA, diag_val, alpha, A, x, y)
     @ccall liboneapi_support.onemklCsparse_trsv(device_queue::syclQueue_t,
                                                 uplo_val::onemklUplo, opA::onemklTranspose,
-                                                diag_val::onemklDiag, A::matrix_handle_t,
+                                                diag_val::onemklDiag,
+                                                alpha::Ref{ComplexF32}, A::matrix_handle_t,
                                                 x::ZePtr{ComplexF32},
                                                 y::ZePtr{ComplexF32})::Cint
 end
 
-function onemklZsparse_trsv(device_queue, uplo_val, opA, diag_val, A, x, y)
+function onemklZsparse_trsv(device_queue, uplo_val, opA, diag_val, alpha, A, x, y)
     @ccall liboneapi_support.onemklZsparse_trsv(device_queue::syclQueue_t,
                                                 uplo_val::onemklUplo, opA::onemklTranspose,
-                                                diag_val::onemklDiag, A::matrix_handle_t,
+                                                diag_val::onemklDiag,
+                                                alpha::Ref{ComplexF64}, A::matrix_handle_t,
                                                 x::ZePtr{ComplexF64},
                                                 y::ZePtr{ComplexF64})::Cint
 end
@@ -5991,6 +6612,54 @@ function onemklZsparse_gemm(device_queue, layout_val, opA, opX, alpha, A, X, col
                                                 X::ZePtr{ComplexF64}, columns::Int64,
                                                 ldx::Int64, beta::Ref{ComplexF64},
                                                 Y::ZePtr{ComplexF64}, ldy::Int64)::Cint
+end
+
+function onemklSsparse_trsm(device_queue, layout_val, opA, opX, uplo_val, diag_val, alpha,
+                            A, X, columns, ldx, Y, ldy)
+    @ccall liboneapi_support.onemklSsparse_trsm(device_queue::syclQueue_t,
+                                                layout_val::onemklLayout,
+                                                opA::onemklTranspose, opX::onemklTranspose,
+                                                uplo_val::onemklUplo, diag_val::onemklDiag,
+                                                alpha::Ref{Cfloat}, A::matrix_handle_t,
+                                                X::ZePtr{Cfloat}, columns::Int64,
+                                                ldx::Int64, Y::ZePtr{Cfloat},
+                                                ldy::Int64)::Cint
+end
+
+function onemklDsparse_trsm(device_queue, layout_val, opA, opX, uplo_val, diag_val, alpha,
+                            A, X, columns, ldx, Y, ldy)
+    @ccall liboneapi_support.onemklDsparse_trsm(device_queue::syclQueue_t,
+                                                layout_val::onemklLayout,
+                                                opA::onemklTranspose, opX::onemklTranspose,
+                                                uplo_val::onemklUplo, diag_val::onemklDiag,
+                                                alpha::Ref{Cdouble}, A::matrix_handle_t,
+                                                X::ZePtr{Cdouble}, columns::Int64,
+                                                ldx::Int64, Y::ZePtr{Cdouble},
+                                                ldy::Int64)::Cint
+end
+
+function onemklCsparse_trsm(device_queue, layout_val, opA, opX, uplo_val, diag_val, alpha,
+                            A, X, columns, ldx, Y, ldy)
+    @ccall liboneapi_support.onemklCsparse_trsm(device_queue::syclQueue_t,
+                                                layout_val::onemklLayout,
+                                                opA::onemklTranspose, opX::onemklTranspose,
+                                                uplo_val::onemklUplo, diag_val::onemklDiag,
+                                                alpha::Ref{ComplexF32}, A::matrix_handle_t,
+                                                X::ZePtr{ComplexF32}, columns::Int64,
+                                                ldx::Int64, Y::ZePtr{ComplexF32},
+                                                ldy::Int64)::Cint
+end
+
+function onemklZsparse_trsm(device_queue, layout_val, opA, opX, uplo_val, diag_val, alpha,
+                            A, X, columns, ldx, Y, ldy)
+    @ccall liboneapi_support.onemklZsparse_trsm(device_queue::syclQueue_t,
+                                                layout_val::onemklLayout,
+                                                opA::onemklTranspose, opX::onemklTranspose,
+                                                uplo_val::onemklUplo, diag_val::onemklDiag,
+                                                alpha::Ref{ComplexF64}, A::matrix_handle_t,
+                                                X::ZePtr{ComplexF64}, columns::Int64,
+                                                ldx::Int64, Y::ZePtr{ComplexF64},
+                                                ldy::Int64)::Cint
 end
 
 function onemklXsparse_set_matmat_data(descr, viewA, opA, viewB, opB, viewC)

--- a/res/support.toml
+++ b/res/support.toml
@@ -276,7 +276,15 @@ use_ccall_macro = true
 3 = "ZePtr{T}"
 5 = "ZePtr{Int64}"
 
+[api.onemklXiamax_64.argtypes]
+3 = "ZePtr{T}"
+5 = "ZePtr{Int64}"
+
 [api.onemklXiamin.argtypes]
+3 = "ZePtr{T}"
+5 = "ZePtr{Int64}"
+
+[api.onemklXiamin_64.argtypes]
 3 = "ZePtr{T}"
 5 = "ZePtr{Int64}"
 
@@ -358,6 +366,16 @@ use_ccall_macro = true
 7 = "ZePtr{Int64}"
 8 = "ZePtr{T}"
 
+[api.onemklXsparse_set_coo_data.argtypes]
+7 = "ZePtr{Int32}"
+8 = "ZePtr{Int32}"
+9 = "ZePtr{T}"
+
+[api.onemklXsparse_set_coo_data_64.argtypes]
+7 = "ZePtr{Int64}"
+8 = "ZePtr{Int64}"
+9 = "ZePtr{T}"
+
 [api.onemklXsparse_gemv.argtypes]
 3 = "Ref{T}"
 5 = "ZePtr{T}"
@@ -377,8 +395,9 @@ use_ccall_macro = true
 9 = "ZePtr{T}"
 
 [api.onemklXsparse_trsv.argtypes]
-6 = "ZePtr{T}"
+5 = "Ref{T}"
 7 = "ZePtr{T}"
+8 = "ZePtr{T}"
 
 [api.onemklXsparse_update_diagonal_values.argtypes]
 4 = "ZePtr{T}"
@@ -602,3 +621,8 @@ use_ccall_macro = true
 8 = "ZePtr{ComplexF64}"
 10 = "ZePtr{Float64}"
 11 = "ZePtr{ComplexF64}"
+
+[api.onemklXsparse_trsm.argtypes]
+7 = "Ref{T}"
+9 = "ZePtr{T}"
+12 = "ZePtr{T}"

--- a/test/level-zero.jl
+++ b/test/level-zero.jl
@@ -190,8 +190,7 @@ arguments(kernel)[1] = Int32(42)
 indirect_access!(kernel, oneL0.ZE_KERNEL_INDIRECT_ACCESS_FLAG_DEVICE)
 @test indirect_access(kernel) == oneL0.ZE_KERNEL_INDIRECT_ACCESS_FLAG_DEVICE
 
-# oneapi-src/level-zero#55
-if !parse(Bool, get(ENV, "ZE_ENABLE_PARAMETER_VALIDATION", "false"))
+if !parameter_validation # oneapi-src/level-zero#55
     attrs = source_attributes(kernel)
     @test attrs isa Vector{<:AbstractString}
 end

--- a/test/onemkl.jl
+++ b/test/onemkl.jl
@@ -1174,6 +1174,7 @@ end
                 for (uplo, diag, wrapper) in [('L', 'N', LowerTriangular), ('L', 'U', UnitLowerTriangular),
                                               ('U', 'N', UpperTriangular), ('U', 'U', UnitUpperTriangular)]
                     (transa == 'N') || continue
+                    alpha = rand(T)
                     A = rand(T, 10, 10) + I
                     A = sparse(A)
                     x = rand(T, 10)
@@ -1186,8 +1187,8 @@ end
                     dy = oneVector{T}(y)
 
                     oneMKL.sparse_optimize_trsv!(uplo, transa, diag, dA)
-                    oneMKL.sparse_trsv!(uplo, transa, diag, dA, dx, dy)
-                    y = wrapper(opa(A)) \ x
+                    oneMKL.sparse_trsv!(uplo, transa, diag, alpha, dA, dx, dy)
+                    y = wrapper(opa(A)) \ (alpha * x)
                     @test y ≈ collect(dy)
                 end
             end

--- a/test/onemkl.jl
+++ b/test/onemkl.jl
@@ -27,10 +27,12 @@ k = 13
             @test testf(axpy!, alpha, rand(T,m), rand(T,m))
         end
 
-        @testset "axpby" begin
-            alpha = rand(T)
-            beta = rand(T)
-            @test testf(axpby!, alpha, rand(T,m), beta, rand(T,m))
+        if !haskey(ENV, "ZE_ENABLE_PARAMETER_VALIDATION")
+            @testset "axpby" begin
+                alpha = rand(T)
+                beta = rand(T)
+                @test testf(axpby!, alpha, rand(T,m), beta, rand(T,m))
+            end
         end
 
         @testset "rotate" begin

--- a/test/onemkl.jl
+++ b/test/onemkl.jl
@@ -27,7 +27,7 @@ k = 13
             @test testf(axpy!, alpha, rand(T,m), rand(T,m))
         end
 
-        if !haskey(ENV, "ZE_ENABLE_PARAMETER_VALIDATION")
+        if !validation_layer # oneapi-src/oneMKL#473
             @testset "axpby" begin
                 alpha = rand(T)
                 beta = rand(T)

--- a/test/onemkl.jl
+++ b/test/onemkl.jl
@@ -3,7 +3,7 @@ if Sys.iswindows()
 else
 
 using oneAPI
-using oneAPI.oneMKL: band, bandex, oneSparseMatrixCSR
+using oneAPI.oneMKL: band, bandex, oneSparseMatrixCSR, oneSparseMatrixCOO
 
 using SparseArrays
 using LinearAlgebra
@@ -1090,27 +1090,39 @@ end
             end
         end
 
-        @testset "sparse gemv" begin
-            for (transa, opa) in [('N', identity), ('T', transpose), ('C', adjoint)]
+        @testset "oneSparseMatrixCOO" begin
+            for S in (Int32, Int64)
                 A = sprand(T, 20, 10, 0.5)
-                x = transa == 'N' ? rand(T, 10) : rand(T, 20)
-                y = transa == 'N' ? rand(T, 20) : rand(T, 10)
+                A = SparseMatrixCSC{T, S}(A)
+                B = oneSparseMatrixCOO(A)
+                A2 = SparseMatrixCSC(B)
+                @test A == A2
+            end
+        end
 
-                dA = oneSparseMatrixCSR(A)
-                dx = oneVector{T}(x)
-                dy = oneVector{T}(y)
+        @testset "sparse gemv" begin
+            @testset  "$SparseMatrix" for SparseMatrix in (oneSparseMatrixCOO, oneSparseMatrixCSR)
+                @testset "transa = $transa" for (transa, opa) in [('N', identity), ('T', transpose), ('C', adjoint)]
+                    A = sprand(T, 20, 10, 0.5)
+                    x = transa == 'N' ? rand(T, 10) : rand(T, 20)
+                    y = transa == 'N' ? rand(T, 20) : rand(T, 10)
 
-                alpha = rand(T)
-                beta = rand(T)
-                oneMKL.sparse_optimize_gemv!(transa, dA)
-                oneMKL.sparse_gemv!(transa, alpha, dA, dx, beta, dy)
-                # @test alpha * opa(A) * x + beta * y ≈ collect(dy)
+                    dA = SparseMatrix(A)
+                    dx = oneVector{T}(x)
+                    dy = oneVector{T}(y)
+
+                    alpha = rand(T)
+                    beta = rand(T)
+                    oneMKL.sparse_optimize_gemv!(transa, dA)
+                    oneMKL.sparse_gemv!(transa, alpha, dA, dx, beta, dy)
+                    @test alpha * opa(A) * x + beta * y ≈ collect(dy)
+                end
             end
         end
 
         @testset "sparse gemm" begin
-            for (transa, opa) in [('N', identity), ('T', transpose), ('C', adjoint)]
-                for (transb, opb) in [('N', identity), ('T', transpose), ('C', adjoint)]
+            @testset "transa = $transa" for (transa, opa) in [('N', identity), ('T', transpose), ('C', adjoint)]
+                @testset "transb = $transb" for (transb, opb) in [('N', identity), ('T', transpose), ('C', adjoint)]
                     (transb == 'N') || continue
                     A = sprand(T, 10, 10, 0.5)
                     B = transb == 'N' ? rand(T, 10, 2) : rand(T, 2, 10)
@@ -1123,7 +1135,7 @@ end
                     alpha = rand(T)
                     beta = rand(T)
                     oneMKL.sparse_gemm!(transa, transb, alpha, dA, dB, beta, dC)
-                    # @test alpha * opa(A) * opb(B) + beta * C ≈ collect(dC)
+                    @test alpha * opa(A) * opb(B) + beta * C ≈ collect(dC)
                 end
             end
         end
@@ -1147,7 +1159,7 @@ end
         end
 
         @testset "sparse trmv" begin
-            for (transa, opa) in [('N', identity), ('T', transpose), ('C', adjoint)]
+            @testset "transa = $transa" for (transa, opa) in [('N', identity), ('T', transpose), ('C', adjoint)]
                 for (uplo, diag, wrapper) in [('L', 'N', LowerTriangular), ('L', 'U', UnitLowerTriangular),
                                               ('U', 'N', UpperTriangular), ('U', 'U', UnitUpperTriangular)]
                     (transa == 'N') || continue
@@ -1172,7 +1184,7 @@ end
         end
 
         @testset "sparse trsv" begin
-            for (transa, opa) in [('N', identity), ('T', transpose), ('C', adjoint)]
+            @testset "transa = $transa" for (transa, opa) in [('N', identity), ('T', transpose), ('C', adjoint)]
                 for (uplo, diag, wrapper) in [('L', 'N', LowerTriangular), ('L', 'U', UnitLowerTriangular),
                                               ('U', 'N', UpperTriangular), ('U', 'U', UnitUpperTriangular)]
                     (transa == 'N') || continue
@@ -1192,6 +1204,36 @@ end
                     oneMKL.sparse_trsv!(uplo, transa, diag, alpha, dA, dx, dy)
                     y = wrapper(opa(A)) \ (alpha * x)
                     @test y ≈ collect(dy)
+                end
+            end
+        end
+
+        @testset "sparse trsm" begin
+            @testset "transa = $transa" for (transa, opa) in [('N', identity), ('T', transpose), ('C', adjoint)]
+                @testset "transx = $transx" for (transx, opx) in [('N', identity), ('T', transpose), ('C', adjoint)]
+                    (transx != 'N') && continue
+                    for (uplo, diag, wrapper) in [('L', 'N', LowerTriangular), ('L', 'U', UnitLowerTriangular),
+                                                  ('U', 'N', UpperTriangular), ('U', 'U', UnitUpperTriangular)]
+                        (transa == 'N') || continue
+                        alpha = rand(T)
+                        A = rand(T, 10, 10) + I
+                        A = sparse(A)
+                        X = transx == 'N' ? rand(T, 10, 4) : rand(T, 4, 10)
+                        Y = rand(T, 10, 4)
+
+                        B = uplo == 'L' ? tril(A) : triu(A)
+                        B = diag == 'U' ? B - Diagonal(B) + I : B
+                        dA = oneSparseMatrixCSR(B)
+                        dX = oneMatrix{T}(X)
+                        dY = oneMatrix{T}(Y)
+
+                        oneMKL.sparse_optimize_trsm!(uplo, transa, diag, dA)
+                        oneMKL.sparse_trsm!(uplo, transa, transx, diag, alpha, dA, dX, dY)
+                        Y = wrapper(opa(A)) \ (alpha * opx(X))
+                        @test Y ≈ collect(dY)
+
+                        oneMKL.sparse_optimize_trsm!(uplo, transa, diag, 4, dA)
+                    end
                 end
             end
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -79,7 +79,7 @@ for (rootpath, dirs, files) in walkdir(@__DIR__)
   end
 end
 ## GPUArrays testsuite
-if !haskey(ENV, "ZE_ENABLE_PARAMETER_VALIDATION")
+if !validation_layer # oneapi-src/oneMKL#473
     for name in keys(TestSuite.tests)
         push!(tests, "gpuarrays$(Base.Filesystem.path_separator)$name")
         test_runners["gpuarrays$(Base.Filesystem.path_separator)$name"] = ()->TestSuite.tests[name](oneArray)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -79,9 +79,11 @@ for (rootpath, dirs, files) in walkdir(@__DIR__)
   end
 end
 ## GPUArrays testsuite
-for name in keys(TestSuite.tests)
-    push!(tests, "gpuarrays$(Base.Filesystem.path_separator)$name")
-    test_runners["gpuarrays$(Base.Filesystem.path_separator)$name"] = ()->TestSuite.tests[name](oneArray)
+if !haskey(ENV, "ZE_ENABLE_PARAMETER_VALIDATION")
+    for name in keys(TestSuite.tests)
+        push!(tests, "gpuarrays$(Base.Filesystem.path_separator)$name")
+        test_runners["gpuarrays$(Base.Filesystem.path_separator)$name"] = ()->TestSuite.tests[name](oneArray)
+    end
 end
 unique!(tests)
 

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -24,6 +24,9 @@ if float64_supported
 end
 TestSuite.supported_eltypes(::Type{<:oneArray}) = eltypes
 
+const validation_layer = parse(Bool, get(ENV, "ZE_ENABLE_VALIDATION_LAYER", "false"))
+const parameter_validation = parse(Bool, get(ENV, "ZE_ENABLE_PARAMETER_VALIDATION", "false"))
+
 using Random
 
 


### PR DESCRIPTION
close #401 

The tests are failing because of an upstream issue:
https://github.com/JuliaGPU/oneAPI.jl/pull/404#issuecomment-2026874806

If we merge this PR and update `oneAPI_Support_jll.jl`, we must bump the version number to `0.4.0`.