### PR TITLE
Another attempt to use mkl_free_buffers

### DIFF
--- a/deps/src/onemkl.cpp
+++ b/deps/src/onemkl.cpp
@@ -4319,18 +4319,10 @@ extern "C" int onemklXsparse_matmat(syclQueue_t device_queue, matrix_handle_t A,
 // other
 
 // oneMKL keeps a cache of SYCL queues and tries to destroy them when unloading the library.
-// that is incompatible with oneAPI.jl destroying queues before that, so expose a function
+// that is incompatible with oneAPI.jl destroying queues before that, so call mkl_free_buffers
 // to manually wipe the device cache when we're destroying queues.
 
-namespace oneapi {
-namespace mkl {
-namespace gpu {
-int clean_gpu_caches();
-}
-}
-}
-
 extern "C" int onemklDestroy() {
-    oneapi::mkl::gpu::clean_gpu_caches();
+    mkl_free_buffers();
     return 0;
 }


### PR DESCRIPTION
MKL team informed us that this should work starting with 2023.1 release.  Hence, try this one again to see if it also fixes the new tear down problem.