### PR TITLE
Revert call to mkl_sycl_destructor

### DIFF
--- a/deps/src/onemkl.cpp
+++ b/deps/src/onemkl.cpp
@@ -4234,10 +4234,9 @@ extern "C" int onemklXsparse_matmat(syclQueue_t device_queue, matrix_handle_t A,
 
 // oneMKL keeps a cache of SYCL queues and tries to destroy them when unloading the library.
 // that is incompatible with oneAPI.jl destroying queues before that, so call mkl_free_buffers
-// and mkl_sycl_destructor to manually cleanup oneMKL cache when we're destroying queues.
+// to manually wipe the device cache when we're destroying queues.
 
 extern "C" int onemklDestroy() {
     mkl_free_buffers();
-    mkl_sycl_destructor();
     return 0;
 }

--- a/deps/src/onemkl.h
+++ b/deps/src/onemkl.h
@@ -2574,7 +2574,6 @@ int onemklXsparse_matmat(syclQueue_t device_queue, matrix_handle_t A, matrix_han
                          matrix_handle_t C, onemklMatmatRequest req, matmat_descr_t
                          descr, int64_t *sizeTempBuffer, void *tempBuffer);
 
-void mkl_sycl_destructor(void);
 int onemklDestroy(void);
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Otherwise, we call ~queue twice, 1 in MKL, 1 in Julia oneAPI.