### PR TITLE
Define `resize!`

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -500,13 +500,13 @@ function Base.resize!(a::oneVector{T}, n::Integer) where {T}
 
     # replace the data with a new one. this 'unshares' the array.
     # as a result, we can safely support resizing unowned buffers.
-    ctx = context()
+    ctx = context(a)
     dev = device(a)
     buf = allocate(buftype(a), ctx, dev, bufsize, Base.datatype_alignment(T))
     ptr = pointer(buf)
     m = min(length(a), n)
     if m > 0
-        unsafe_copyto!(device(a), ptr, pointer(a), m)
+        unsafe_copyto!(ctx, dev, ptr, pointer(a), m)
     end
     new_data = DataRef(buf) do buf
         free(buf)

--- a/src/array.jl
+++ b/src/array.jl
@@ -503,7 +503,7 @@ function Base.resize!(a::oneVector{T}, n::Integer) where {T}
     ctx = context(a)
     dev = device(a)
     buf = allocate(buftype(a), ctx, dev, bufsize, Base.datatype_alignment(T))
-    ptr = pointer(buf)
+    ptr = convert(ZePtr{T}, buf)
     m = min(length(a), n)
     if m > 0
         unsafe_copyto!(ctx, dev, ptr, pointer(a), m)

--- a/src/array.jl
+++ b/src/array.jl
@@ -478,3 +478,45 @@ function Base.unsafe_wrap(::Type{Array}, arr::oneArray{T,N,oneL0.SharedBuffer}) 
   ptr = reinterpret(Ptr{T}, pointer(arr))
   unsafe_wrap(Array, ptr, size(arr))
 end
+
+## resizing
+
+"""
+  resize!(a::oneVector, n::Integer)
+
+Resize `a` to contain `n` elements. If `n` is smaller than the current collection length,
+the first `n` elements will be retained. If `n` is larger, the new elements are not
+guaranteed to be initialized.
+"""
+function Base.resize!(a::oneVector{T}, n::Integer) where {T}
+    # TODO: add additional space to allow for quicker resizing
+    maxsize = n * sizeof(T)
+    bufsize = if isbitstype(T)
+        maxsize
+    else
+        # type tag array past the data
+        maxsize + n
+    end
+
+    # replace the data with a new one. this 'unshares' the array.
+    # as a result, we can safely support resizing unowned buffers.
+    ctx = context()
+    dev = device(a)
+    buf = allocate(buftype(a), ctx, dev, bufsize, Base.datatype_alignment(T))
+    ptr = ZePtr{T}(buf)
+    m = min(length(a), n)
+    if m > 0
+        unsafe_copyto!(device(a), ptr, pointer(a), m)
+    end
+    new_data = DataRef(buf) do buf
+        free(buf)
+    end
+    unsafe_free!(a)
+
+    a.data = new_data
+    a.dims = (n,)
+    a.maxsize = maxsize
+    a.offset = 0
+
+    a
+end

--- a/src/array.jl
+++ b/src/array.jl
@@ -503,7 +503,7 @@ function Base.resize!(a::oneVector{T}, n::Integer) where {T}
     ctx = context()
     dev = device(a)
     buf = allocate(buftype(a), ctx, dev, bufsize, Base.datatype_alignment(T))
-    ptr = ZePtr{T}(buf)
+    ptr = pointer(buf)
     m = min(length(a), n)
     if m > 0
         unsafe_copyto!(device(a), ptr, pointer(a), m)

--- a/test/array.jl
+++ b/test/array.jl
@@ -74,3 +74,24 @@ end
   e = c .+ d
   @test oneAPI.buftype(e) == oneL0.SharedBuffer
 end
+
+@testset "resizing" begin
+  a = oneArray([1,2,3])
+
+  resize!(a, 3)
+  @test length(a) == 3
+  @test Array(a) == [1,2,3]
+
+  resize!(a, 5)
+  @test length(a) == 5
+  @test Array(a)[1:3] == [1,2,3]
+
+  resize!(a, 2)
+  @test length(a) == 2
+  @test Array(a)[1:2] == [1,2]
+
+  b = oneArray{Int}(undef, 0)
+  @test length(b) == 0
+  resize!(b, 1)
+  @test length(b) == 1
+end


### PR DESCRIPTION
This is a draft of an implementation of `resize!` for `oneArray`.

It is similar to the implementations for [`CuArray`](https://github.com/JuliaGPU/CUDA.jl/commit/f900010de53812b69239d0b9dfae5cd47fe97563), [`ROCArray`](https://github.com/JuliaGPU/AMDGPU.jl/pull/333), and [`MtlArray`](https://github.com/JuliaGPU/Metal.jl/pull/279).

I don't have access to an Intel GPU so don't have any way of testing it, so the current implementation is most likely wrong. I'm hoping to get some help from someone who is capable of helping, and/or use the CI tests to guide me towards a correct implementation.

In conjunction with https://github.com/JuliaGPU/GPUArrays.jl/pull/533, this will allow `append!` to be defined for `oneArray`.

@tgymnich @maleadt