### PR TITLE
Queue operations on the current device, not the one owning the array.

### DIFF
--- a/lib/mkl/wrappers_blas.jl
+++ b/lib/mkl/wrappers_blas.jl
@@ -153,7 +153,7 @@ for (fname, elty) in ((:onemklSsymm, :Float32),
             lda = max(1,stride(A,2))
             ldb = max(1,stride(B,2))
             ldc = max(1,stride(C,2))
-            queue = global_queue(context(A), device(A))
+            queue = global_queue(context(A), device())
             $fname(sycl_queue(queue), side, uplo, m, n, alpha, A, lda, B, ldb,
                    beta, C, ldc)
             C
@@ -193,7 +193,7 @@ for (fname, elty) in ((:onemklSsyrk, :Float32),
             k  = size(A, trans == 'N' ? 2 : 1)
             lda = max(1,stride(A,2))
             ldc = max(1,stride(C,2))
-            queue = global_queue(context(A), device(A))
+            queue = global_queue(context(A), device())
             $fname(sycl_queue(queue), uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
             C
         end
@@ -234,7 +234,7 @@ for (fname, elty) in ((:onemklDsyr2k,:Float64),
             lda = max(1,stride(A,2))
             ldb = max(1,stride(B,2))
             ldc = max(1,stride(C,2))
-            queue = global_queue(context(A), device(A))
+            queue = global_queue(context(A), device())
             $fname(sycl_queue(queue), uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
             C
         end
@@ -268,7 +268,7 @@ for (fname, elty) in ((:onemklZherk, :ComplexF64),
             k  = size(A, trans == 'N' ? 2 : 1)
             lda = max(1,stride(A,2))
             ldc = max(1,stride(C,2))
-            queue = global_queue(context(A), device(A))
+            queue = global_queue(context(A), device())
             $fname(sycl_queue(queue), uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
             C
         end
@@ -305,7 +305,7 @@ for (fname, elty) in ((:onemklZher2k,:ComplexF64),
             lda = max(1,stride(A,2))
             ldb = max(1,stride(B,2))
             ldc = max(1,stride(C,2))
-            queue = global_queue(context(A), device(A))
+            queue = global_queue(context(A), device())
             $fname(sycl_queue(queue), uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
             C
         end
@@ -336,7 +336,7 @@ for (fname, elty) in ((:onemklSgemv, :Float32),
                        x::oneStridedArray{$elty},
                        beta::Number,
                        y::oneStridedArray{$elty})
-            queue = global_queue(context(x), device(x))
+            queue = global_queue(context(x), device())
              # handle trans
              m,n = size(a)
              # check dimensions
@@ -380,7 +380,7 @@ for (fname, elty) in ((:onemklChemv,:ComplexF32),
             lda = max(1,stride(A,2))
             incx = stride(x,1)
             incy = stride(y,1)
-            queue = global_queue(context(x), device(x))
+            queue = global_queue(context(x), device())
             $fname(sycl_queue(queue), uplo, n, alpha, A, lda, x, incx, beta, y, incy)
             y
         end
@@ -414,7 +414,7 @@ for (fname, elty) in ((:onemklChbmv,:ComplexF32),
             lda = max(1,stride(A,2))
             incx = stride(x,1)
             incy = stride(y,1)
-            queue = global_queue(context(x), device(x))
+            queue = global_queue(context(x), device())
             $fname(sycl_queue(queue), uplo, n, k, alpha, A, lda, x, incx, beta, y, incy)
             y
         end
@@ -443,7 +443,7 @@ for (fname, elty) in ((:onemklCher,:ComplexF32),
             length(x) == n || throw(DimensionMismatch("Length of vector must be the same as the matrix dimensions"))
             incx = stride(x,1)
             lda = max(1,stride(A,2))
-            queue = global_queue(context(x), device(x))
+            queue = global_queue(context(x), device())
             $fname(sycl_queue(queue), uplo, n, alpha, x, incx, A, lda)
             A
         end
@@ -466,7 +466,7 @@ for (fname, elty) in ((:onemklCher2,:ComplexF32),
             incx = stride(x,1)
             incy = stride(y,1)
             lda = max(1,stride(A,2))
-            queue = global_queue(context(x), device(x))
+            queue = global_queue(context(x), device())
             $fname(sycl_queue(queue), uplo, n, alpha, x, incx, y, incy, A, lda)
             A
         end
@@ -486,7 +486,7 @@ for (fname, elty) in
                        alpha::Number,
                        x::oneStridedArray{$elty},
                        y::oneStridedArray{$elty})
-            queue = global_queue(context(x), device(x))
+            queue = global_queue(context(x), device())
             alpha = $elty(alpha)
             $fname(sycl_queue(queue), n, alpha, x, stride(x,1), y, stride(y,1))
             y
@@ -506,7 +506,7 @@ for (fname, elty) in
                         x::oneStridedArray{$elty},
                         beta::Number,
                         y::oneStridedArray{$elty})
-            queue = global_queue(context(x), device(x))
+            queue = global_queue(context(x), device())
             alpha = $elty(alpha)
             beta = $elty(beta)
             $fname(sycl_queue(queue), n, alpha, x, stride(x,1), beta, y, stride(y,1))
@@ -528,7 +528,7 @@ for (fname, elty, cty, sty, supty) in ((:onemklSrot,:Float32,:Float32,:Float32,:
                       y::oneStridedArray{$elty},
                       c::Real,
                       s::$supty)
-            queue = global_queue(context(x), device(x))
+            queue = global_queue(context(x), device())
             c = $cty(c)
             s = $sty(s)
             $fname(sycl_queue(queue), n, x, stride(x, 1), y, stride(y, 1), c, s)
@@ -560,7 +560,7 @@ for (fname, elty) in
         function scal!(n::Integer,
                        alpha::$elty,
                        x::oneStridedArray{$elty})
-            queue = global_queue(context(x), device(x))
+            queue = global_queue(context(x), device())
             $fname(sycl_queue(queue), n, alpha, x, stride(x,1))
             x
         end
@@ -586,7 +586,7 @@ for (fname, elty, ret_type) in
      (:onemklZnrm2, :ComplexF64,:Float64))
     @eval begin
         function nrm2(n::Integer, x::oneStridedArray{$elty})
-            queue = global_queue(context(x), device(x))
+            queue = global_queue(context(x), device())
             result = oneArray{$ret_type}([0]);
             $fname(sycl_queue(queue), n, x, stride(x,1), result)
             res = Array(result)
@@ -616,7 +616,7 @@ for (jname, fname, elty) in
         function $jname(n::Integer,
                          x::oneStridedArray{$elty},
                          y::oneStridedArray{$elty})
-            queue = global_queue(context(x), device(x))
+            queue = global_queue(context(x), device())
             result = oneArray{$elty}([0]);
             $fname(sycl_queue(queue), n, x, stride(x,1), y, stride(y,1), result)
             res = Array(result)
@@ -649,7 +649,7 @@ for (fname, elty) in ((:onemklSsbmv, :Float32),
             if !(1<=(1+k)<=n) throw(DimensionMismatch("Incorrect number of bands")) end
             if m < 1+k throw(DimensionMismatch("Array A has fewer than 1+k rows")) end
             if n != length(x) || n != length(y) throw(DimensionMismatch("")) end
-            queue = global_queue(context(x), device(x))
+            queue = global_queue(context(x), device())
             lda = max(1, stride(a,2))
             incx = stride(x,1)
             incy = stride(y,1)
@@ -676,7 +676,7 @@ for (fname, elty, celty) in ((:onemklCSscal, :Float32, :ComplexF32),
         function scal!(n::Integer,
                        alpha::$elty,
                        x::oneStridedArray{$celty})
-            queue = global_queue(context(x), device(x))
+            queue = global_queue(context(x), device())
             $fname(sycl_queue(queue), n, alpha, x, stride(x,1))
         end
     end
@@ -696,7 +696,7 @@ for (fname, elty) in ((:onemklSger, :Float32),
             m,n = size(a)
             m == length(x) || throw(DimensionMismatch(""))
             n == length(y) || throw(DimensionMismatch(""))
-            queue = global_queue(context(x), device(x))
+            queue = global_queue(context(x), device())
             $fname(sycl_queue(queue), m, n, alpha, x, stride(x,1), y, stride(y,1), a, max(1,stride(a,2)))
             a
         end
@@ -714,7 +714,7 @@ for (fname, elty) in ((:onemklSspr, :Float32),
             n = round(Int, (sqrt(8*length(A))-1)/2)
             length(x) == n || throw(DimensionMismatch("Length of vector must be the same as the matrix dimensions"))
             incx = stride(x,1)
-            queue = global_queue(context(x), device(x))
+            queue = global_queue(context(x), device())
             $fname(sycl_queue(queue), uplo, n, alpha, x, incx, A)
             A
         end
@@ -738,7 +738,7 @@ for (fname, elty) in ((:onemklSsymv,:Float32),
             lda = max(1,stride(A,2))
             incx = stride(x,1)
             incy = stride(y,1)
-            queue = global_queue(context(x), device(x))
+            queue = global_queue(context(x), device())
             $fname(sycl_queue(queue), uplo, n, alpha, A, lda, x, incx, beta, y, incy)
             y
         end
@@ -764,7 +764,7 @@ for (fname, elty) in ((:onemklSsyr,:Float32),
             length(x) == n || throw(DimensionMismatch("Length of vector must be the same as the matrix dimensions"))
             incx = stride(x,1)
             lda = max(1,stride(A,2))
-            queue = global_queue(context(x), device(x))
+            queue = global_queue(context(x), device())
             $fname(sycl_queue(queue), uplo, n, alpha, x, incx, A, lda)
             A
         end
@@ -786,7 +786,7 @@ for (fname, elty) in
         function copy!(n::Integer,
                        x::oneStridedArray{$elty},
                        y::oneStridedArray{$elty})
-            queue = global_queue(context(x), device(x))
+            queue = global_queue(context(x), device())
             $fname(sycl_queue(queue), n, x, stride(x, 1), y, stride(y, 1))
             y
         end
@@ -807,7 +807,7 @@ for (fname, elty, ret_type) in
         function asum(n::Integer,
                       x::oneStridedArray{$elty})
             result = oneArray{$ret_type}([0])
-            queue = global_queue(context(x), device(x))
+            queue = global_queue(context(x), device())
             $fname(sycl_queue(queue), n, x, stride(x, 1), result)
             res = Array(result)
             return res[1]
@@ -824,7 +824,7 @@ for (fname, elty) in
     @eval begin
         function iamax(x::oneStridedArray{$elty})
             n = length(x)
-            queue = global_queue(context(x), device(x))
+            queue = global_queue(context(x), device())
             result = oneArray{Int64}([0]);
             $fname(sycl_queue(queue), n, x, stride(x, 1), result, 'O')
             return Array(result)[1]
@@ -842,7 +842,7 @@ for (fname, elty) in
         function iamin(x::StridedArray{$elty})
             n = length(x)
             result = oneArray{Int64}([0]);
-            queue = global_queue(context(x), device(x))
+            queue = global_queue(context(x), device())
             $fname(sycl_queue(queue),n, x, stride(x, 1), result, 'O')
             return Array(result)[1]
         end
@@ -859,7 +859,7 @@ for (fname, elty) in ((:onemklSswap,:Float32),
             x::oneStridedArray{$elty},
             y::oneStridedArray{$elty})
             # Assuming both memory allocated on same device & context
-            queue = global_queue(context(x), device(x))
+            queue = global_queue(context(x), device())
             $fname(sycl_queue(queue), n, x, stride(x, 1), y, stride(y, 1))
             x, y
         end
@@ -885,7 +885,7 @@ for (fname, elty) in ((:onemklSgbmv, :Float32),
             n = size(a,2)
             length(x) == (trans == 'N' ? n : m) && length(y) ==
                          (trans == 'N' ? m : n) || throw(DimensionMismatch(""))
-            queue = global_queue(context(x), device(x))
+            queue = global_queue(context(x), device())
             lda = max(1, stride(a,2))
             incx = stride(x,1)
             incy = stride(y,1)
@@ -903,7 +903,7 @@ function gbmv(trans::Char,
               x::oneStridedArray{T}) where T
     n = size(a,2)
     leny = trans == 'N' ? m : n
-    queue = global_queue(context(x), device(x))
+    queue = global_queue(context(x), device())
     gbmv!(trans, m, kl, ku, alpha, a, x, zero(T), similar(x, leny))
 end
 function gbmv(trans::Char,
@@ -912,7 +912,7 @@ function gbmv(trans::Char,
               ku::Integer,
               a::oneStridedArray{T},
               x::oneStridedArray{T}) where T
-    queue = global_queue(context(x), device(x))
+    queue = global_queue(context(x), device())
     gbmv(trans, m, kl, ku, one(T), a, x)
 end
 
@@ -932,7 +932,7 @@ for (fname, elty) in ((:onemklSspmv, :Float32),
             end
             incx = stride(x,1)
             incy = stride(y,1)
-            queue = global_queue(context(x), device(x))
+            queue = global_queue(context(x), device())
             $fname(sycl_queue(queue), uplo, n, alpha, A, x, incx, beta, y, incy)
             y
         end
@@ -966,7 +966,7 @@ for (fname, elty) in ((:onemklStbsv, :Float32),
             if n != length(x) throw(DimensionMismatch("")) end
             lda = max(1,stride(A,2))
             incx = stride(x,1)
-            queue = global_queue(context(x), device(x))
+            queue = global_queue(context(x), device())
             $fname(sycl_queue(queue), uplo, trans, diag, n, k, A, lda, x, incx)
             x
         end
@@ -996,7 +996,7 @@ for (fname, elty) in ((:onemklStbmv,:Float32),
             if n != length(x) throw(DimensionMismatch("")) end
             lda = max(1,stride(A,2))
             incx = stride(x,1)
-            queue = global_queue(context(x), device(x))
+            queue = global_queue(context(x), device())
             $fname(sycl_queue(queue), uplo, trans, diag, n, k, A, lda, x, incx)
             x
         end
@@ -1029,7 +1029,7 @@ for (fname, elty) in ((:onemklStrmv, :Float32),
             end
             lda = max(1,stride(A,2))
             incx = stride(x,1)
-            queue = global_queue(context(x), device(x))
+            queue = global_queue(context(x), device())
             $fname(sycl_queue(queue), uplo, trans, diag, n, A, lda, x, incx)
             x
         end
@@ -1061,7 +1061,7 @@ for (fname, elty) in ((:onemklStrsv, :Float32),
             end
             lda = max(1,stride(A,2))
             incx = stride(x,1)
-            queue = global_queue(context(x), device(x))
+            queue = global_queue(context(x), device())
             $fname(sycl_queue(queue), uplo, trans, diag, n, A, lda, x, incx)
             x
         end
@@ -1096,7 +1096,7 @@ for (mmname, smname, elty) in
             if nA != (side == 'L' ? m : n) throw(DimensionMismatch("trmm!")) end
             lda = max(1,stride(A,2))
             ldb = max(1,stride(B,2))
-            queue = global_queue(context(A), device(A))
+            queue = global_queue(context(A), device())
             $mmname(sycl_queue(queue), side, uplo, transa, diag, m, n, alpha, A, lda, B, ldb)
             B
         end
@@ -1114,7 +1114,7 @@ for (mmname, smname, elty) in
             if nA != (side == 'L' ? m : n) throw(DimensionMismatch("trsm!")) end
             lda = max(1,stride(A,2))
             ldb = max(1,stride(B,2))
-            queue = global_queue(context(A), device(A))
+            queue = global_queue(context(A), device())
             $smname(sycl_queue(queue), side, uplo, transa, diag, m, n, alpha, A, lda, B, ldb)
             B
         end
@@ -1160,7 +1160,7 @@ for (fname, elty) in ((:onemklZhemm,:ComplexF64),
             lda = max(1,stride(A,2))
             ldb = max(1,stride(B,2))
             ldc = max(1,stride(C,2))
-            queue = global_queue(context(A), device(A))
+            queue = global_queue(context(A), device())
             $fname(sycl_queue(queue), side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
             C
         end
@@ -1202,9 +1202,9 @@ for (fname, elty) in
             ldb = max(1,stride(B,2))
             ldc = max(1,stride(C,2))
 
-            device(A) == device(B) == device(C) || error("Multi-device GEMM not supported")
+            device() == device(B) == device(C) || error("Multi-device GEMM not supported")
             context(A) == context(B) == context(C) || error("Multi-context GEMM not supported")
-            queue = global_queue(context(A), device(A))
+            queue = global_queue(context(A), device())
 
             alpha = $elty(alpha)
             beta = $elty(beta)
@@ -1249,7 +1249,7 @@ for (fname, elty) in ((:onemklSdgmm, :Float32),
             lda = max(1,stride(A,2))
             incx = stride(X,1)
             ldc = max(1,stride(C,2))
-            queue = global_queue(context(A), device(A))
+            queue = global_queue(context(A), device())
             $fname(sycl_queue(queue), mode, m, n, A, lda, X, incx, C, ldc)
             C
         end
@@ -1292,7 +1292,7 @@ for (fname, elty) in
             strideB = size(B, 3) == 1 ? 0 : stride(B, 3)
             strideC = stride(C, 3)
             batchCount = size(C, 3)
-            queue = global_queue(context(A), device(A))
+            queue = global_queue(context(A), device())
             alpha = $elty(alpha)
             beta = $elty(beta)
             $fname(sycl_queue(queue), transA, transB, m, n, k, alpha, A, lda, strideA, B,

--- a/lib/mkl/wrappers_lapack.jl
+++ b/lib/mkl/wrappers_lapack.jl
@@ -10,7 +10,7 @@ for (bname, fname, elty) in ((:onemklSpotrf_scratchpad_size, :onemklSpotrf, :Flo
             n = checksquare(A)
             lda = max(1, stride(A, 2))
 
-            queue = global_queue(context(A), device(A))
+            queue = global_queue(context(A), device())
             scratchpad_size = $bname(sycl_queue(queue), uplo, n, lda)
             scratchpad = oneVector{$elty}(undef, scratchpad_size)
             $fname(sycl_queue(queue), uplo, n, A, lda, scratchpad, scratchpad_size)
@@ -38,7 +38,7 @@ for (bname, fname, elty) in ((:onemklSpotrs_scratchpad_size, :onemklSpotrs, :Flo
             lda  = max(1, stride(A, 2))
             ldb  = max(1, stride(B, 2))
 
-            queue = global_queue(context(A), device(A))
+            queue = global_queue(context(A), device())
             scratchpad_size = $bname(sycl_queue(queue), uplo, n, nrhs, lda, ldb)
             scratchpad = oneVector{$elty}(undef, scratchpad_size)
             $fname(sycl_queue(queue), uplo, n, nrhs, A, lda, B, ldb, scratchpad, scratchpad_size)
@@ -60,7 +60,7 @@ for (bname, fname, elty) in ((:onemklSpotri_scratchpad_size, :onemklSpotri, :Flo
             n = checksquare(A)
             lda = max(1, stride(A, 2))
 
-            queue = global_queue(context(A), device(A))
+            queue = global_queue(context(A), device())
             scratchpad_size = $bname(sycl_queue(queue), uplo, n, lda)
             scratchpad = oneVector{$elty}(undef, scratchpad_size)
             $fname(sycl_queue(queue), uplo, n, A, lda, scratchpad, scratchpad_size)
@@ -83,7 +83,7 @@ for (bname, fname, elty) in ((:onemklSsytrf_scratchpad_size, :onemklSsytrf, :Flo
             n = checksquare(A)
             lda = max(1, stride(A, 2))
 
-            queue = global_queue(context(A), device(A))
+            queue = global_queue(context(A), device())
             scratchpad_size = $bname(sycl_queue(queue), uplo, n, lda)
             scratchpad = oneVector{$elty}(undef, scratchpad_size)
             $fname(sycl_queue(queue), uplo, n, A, lda, ipiv, scratchpad, scratchpad_size)
@@ -115,7 +115,7 @@ for (bname, fname, elty) in ((:onemklSgetrf_scratchpad_size, :onemklSgetrf, :Flo
             m,n = size(A)
             lda = max(1, stride(A, 2))
 
-            queue = global_queue(context(A), device(A))
+            queue = global_queue(context(A), device())
             scratchpad_size = $bname(sycl_queue(queue), m, n, lda)
             scratchpad = oneVector{$elty}(undef, scratchpad_size)
             $fname(sycl_queue(queue), m, n, A, lda, ipiv, scratchpad, scratchpad_size)
@@ -151,7 +151,7 @@ for (bname, fname, elty) in ((:onemklSgetrs_scratchpad_size, :onemklSgetrs, :Flo
             lda  = max(1, stride(A, 2))
             ldb  = max(1, stride(B, 2))
 
-            queue = global_queue(context(A), device(A))
+            queue = global_queue(context(A), device())
             scratchpad_size = $bname(sycl_queue(queue), trans, n, nrhs, lda, ldb)
             scratchpad = oneVector{UInt8}(undef, scratchpad_size)
             $fname(sycl_queue(queue), trans, n, nrhs, A, lda, ipiv, B, ldb, scratchpad, scratchpad_size)
@@ -171,7 +171,7 @@ for (bname, fname, elty) in ((:onemklSgetri_scratchpad_size, :onemklSgetri, :Flo
             n = checksquare(A)
             lda = max(1, stride(A, 2))
 
-            queue = global_queue(context(A), device(A))
+            queue = global_queue(context(A), device())
             scratchpad_size = $bname(sycl_queue(queue), n, lda)
             scratchpad = oneVector{$elty}(undef, scratchpad_size)
             $fname(sycl_queue(queue), n, A, lda, ipiv, scratchpad, scratchpad_size)
@@ -197,7 +197,7 @@ for (bname, fname, elty) in ((:onemklSgeqrf_scratchpad_size, :onemklSgeqrf, :Flo
             m,n = size(A)
             lda = max(1, stride(A, 2))
 
-            queue = global_queue(context(A), device(A))
+            queue = global_queue(context(A), device())
             scratchpad_size = $bname(sycl_queue(queue), m, n, lda)
             scratchpad = oneVector{$elty}(undef, scratchpad_size)
             $fname(sycl_queue(queue), m, n, A, lda, tau, scratchpad, scratchpad_size)
@@ -237,7 +237,7 @@ for (bname, fname, elty) in ((:onemklSormqr_scratchpad_size, :onemklSormqr, :Flo
             lda = max(1, stride(A, 2))
             ldc = max(1, stride(C, 2))
 
-            queue = global_queue(context(A), device(A))
+            queue = global_queue(context(A), device())
             scratchpad_size = $bname(sycl_queue(queue), side, trans, m, n, k, lda, ldc)
             scratchpad = oneVector{$elty}(undef, scratchpad_size)
             $fname(sycl_queue(queue), side, trans, m, n, k, A, lda, tau, C, ldc, scratchpad, scratchpad_size)
@@ -258,7 +258,7 @@ for (bname, fname, elty) in ((:onemklSorgqr_scratchpad_size, :onemklSorgqr, :Flo
             lda = max(1, stride(A, 2))
             k = length(tau)
 
-            queue = global_queue(context(A), device(A))
+            queue = global_queue(context(A), device())
             scratchpad_size = $bname(sycl_queue(queue), m, n, k, lda)
             scratchpad = oneVector{$elty}(undef, scratchpad_size)
             $fname(sycl_queue(queue), m, n, k, A, lda, tau, scratchpad, scratchpad_size)
@@ -284,7 +284,7 @@ for (bname, fname, elty, relty) in ((:onemklSgebrd_scratchpad_size, :onemklSgebr
             tauq = oneVector{$elty}(undef, k)
             taup = oneVector{$elty}(undef, k)
 
-            queue = global_queue(context(A), device(A))
+            queue = global_queue(context(A), device())
             scratchpad_size = $bname(sycl_queue(queue), m, n, lda)
             scratchpad = oneVector{$elty}(undef, scratchpad_size)
             $fname(sycl_queue(queue), m, n, A, lda, D, E, tauq, taup, scratchpad, scratchpad_size)
@@ -329,7 +329,7 @@ for (bname, fname, elty, relty) in ((:onemklSgesvd_scratchpad_size, :onemklSgesv
             end
             ldvt = Vt == oneArray{$elty}(undef, 0, 0) ? 1 : max(1, stride(Vt, 2))
 
-            queue = global_queue(context(A), device(A))
+            queue = global_queue(context(A), device())
             scratchpad_size = $bname(sycl_queue(queue), jobu, jobvt, m, n, lda, ldu, ldvt)
             scratchpad = oneVector{$elty}(undef, scratchpad_size)
             $fname(sycl_queue(queue), jobu, jobvt, m, n, A, lda, S, U, ldu, Vt, ldvt, scratchpad, scratchpad_size)
@@ -353,7 +353,7 @@ for (jname, bname, fname, elty, relty) in ((:syevd!, :onemklSsyevd_scratchpad_si
             lda = max(1, stride(A, 2))
             W = oneVector{$relty}(undef, n)
 
-            queue = global_queue(context(A), device(A))
+            queue = global_queue(context(A), device())
             scratchpad_size = $bname(sycl_queue(queue), jobz, uplo, n, lda)
             scratchpad = oneVector{$elty}(undef, scratchpad_size)
             $fname(sycl_queue(queue), jobz, uplo, n, A, lda, W, scratchpad, scratchpad_size)
@@ -388,7 +388,7 @@ for (jname, bname, fname, elty, relty) in ((:sygvd!, :onemklSsygvd_scratchpad_si
             ldb = max(1, stride(B, 2))
             W = oneVector{$relty}(undef, n)
 
-            queue = global_queue(context(A), device(A))
+            queue = global_queue(context(A), device())
             scratchpad_size = $bname(sycl_queue(queue), itype, jobz, uplo, n, lda, ldb)
             scratchpad = oneVector{$elty}(undef, scratchpad_size)
             $fname(sycl_queue(queue), itype, jobz, uplo, n, A, lda, B, ldb, W, scratchpad, scratchpad_size)

--- a/lib/mkl/wrappers_sparse.jl
+++ b/lib/mkl/wrappers_sparse.jl
@@ -22,7 +22,7 @@ for (fname, elty, intty) in ((:onemklSsparse_set_csr_data   , :Float32   , :Int3
             colVal = oneVector{$intty}(At.rowval)
             nzVal = oneVector{$elty}(At.nzval)
             nnzA = length(At.nzval)
-            queue = global_queue(context(nzVal), device(nzVal))
+            queue = global_queue(context(nzVal), device())
             $fname(sycl_queue(queue), handle_ptr[], m, n, 'O', rowPtr, colVal, nzVal)
             dA = oneSparseMatrixCSR{$elty, $intty}(handle_ptr[], rowPtr, colVal, nzVal, (m,n), nnzA)
             finalizer(sparse_release_matrix_handle, dA)
@@ -56,7 +56,7 @@ for (fname, elty, intty) in ((:onemklSsparse_set_coo_data   , :Float32   , :Int3
             colInd = oneVector{$intty}(col)
             nzVal = oneVector{$elty}(val)
             nnzA = length(val)
-            queue = global_queue(context(nzVal), device(nzVal))
+            queue = global_queue(context(nzVal), device())
             $fname(sycl_queue(queue), handle_ptr[], m, n, nnzA, 'O', rowInd, colInd, nzVal)
             dA = oneSparseMatrixCOO{$elty, $intty}(handle_ptr[], rowInd, colInd, nzVal, (m,n), nnzA)
             finalizer(sparse_release_matrix_handle, dA)
@@ -84,7 +84,7 @@ for SparseMatrix in (:oneSparseMatrixCSR, :oneSparseMatrixCOO)
                                   beta::Number,
                                   y::oneStridedVector{$elty})
 
-                queue = global_queue(context(x), device(x))
+                queue = global_queue(context(x), device())
                 $fname(sycl_queue(queue), trans, alpha, A.handle, x, beta, y)
                 y
             end
@@ -120,7 +120,7 @@ for (fname, elty) in ((:onemklSsparse_gemm, :Float32),
             nrhs = size(B, 2)
             ldb = max(1,stride(B,2))
             ldc = max(1,stride(C,2))
-            queue = global_queue(context(C), device(C))
+            queue = global_queue(context(C), device())
             $fname(sycl_queue(queue), 'C', transa, transb, alpha, A.handle, B, nrhs, ldb, beta, C, ldc)
             C
         end
@@ -139,7 +139,7 @@ for (fname, elty) in ((:onemklSsparse_symv, :Float32),
                               beta::Number,
                               y::oneStridedVector{$elty})
 
-            queue = global_queue(context(y), device(y))
+            queue = global_queue(context(y), device())
             $fname(sycl_queue(queue), uplo, alpha, A.handle, x, beta, y)
             y
         end
@@ -160,7 +160,7 @@ for (fname, elty) in ((:onemklSsparse_trmv, :Float32),
                               beta::Number,
                               y::oneStridedVector{$elty})
 
-            queue = global_queue(context(y), device(y))
+            queue = global_queue(context(y), device())
             $fname(sycl_queue(queue), uplo, trans, diag, alpha, A.handle, x, beta, y)
             y
         end
@@ -186,7 +186,7 @@ for (fname, elty) in ((:onemklSsparse_trsv, :Float32),
                               x::oneStridedVector{$elty},
                               y::oneStridedVector{$elty})
 
-            queue = global_queue(context(y), device(y))
+            queue = global_queue(context(y), device())
             $fname(sycl_queue(queue), uplo, trans, diag, alpha, A.handle, x, y)
             y
         end
@@ -222,7 +222,7 @@ for (fname, elty) in ((:onemklSsparse_trsm, :Float32),
             nrhs = size(X, 2)
             ldx = max(1,stride(X,2))
             ldy = max(1,stride(Y,2))
-            queue = global_queue(context(Y), device(Y))
+            queue = global_queue(context(Y), device())
             $fname(sycl_queue(queue), 'C', transA, transX, uplo, diag, alpha, A.handle, X, nrhs, ldx, Y, ldy)
             Y
         end


### PR DESCRIPTION
When using host or shared buffer types, there isn't a clear owner, so let's use the CUDA semantics of executing on the currently-active device. This makes it possible to properly synchronize before copying host memory, which is needed for correctness.