### PR TITLE
Revert "Use the version 2024.2.1 for CI"

### DIFF
--- a/deps/Project.toml
+++ b/deps/Project.toml
@@ -12,4 +12,4 @@ oneAPI_Level_Zero_Headers_jll = "f4bc562b-d309-54f8-9efb-476e56f0410d"
 oneAPI_Support_Headers_jll = "24f86df5-245d-5634-a4cc-32433d9800b3"
 
 [compat]
-oneAPI_Support_Headers_jll = "=2024.2.1"
+oneAPI_Support_Headers_jll = "=2024.2.0"

--- a/deps/build_local.jl
+++ b/deps/build_local.jl
@@ -45,7 +45,7 @@ if !isfile(joinpath(conda_dir, "condarc-julia.yml"))
     touch(joinpath(conda_dir, "conda-meta", "history"))
 end
 Conda.add_channel("https://software.repos.intel.com/python/conda/", conda_dir)
-Conda.add(["dpcpp_linux-64=2024.2.1", "mkl-devel-dpcpp=2024.2.1"], conda_dir)
+Conda.add(["dpcpp_linux-64=2024.2.0", "mkl-devel-dpcpp=2024.2.0"], conda_dir)
 
 Conda.list(conda_dir)
 


### PR DESCRIPTION
Reverts JuliaGPU/oneAPI.jl#467. Looks like v2024.2.1 is problematic wrt. building the support library on Yggdrasil, so let's temporarily revert the change here too so that we can tag a release first.

x-ref https://github.com/JuliaPackaging/Yggdrasil/pull/9552