### PR TITLE
Make package loadable on macOS

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "oneAPI"
 uuid = "8f75cd03-7ff8-4ecb-9b8f-daf728133b1b"
 authors = ["Tim Besard <tim.besard@gmail.com>"]
-version = "2.0.1"
+version = "2.0.2"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/oneAPI.jl
+++ b/src/oneAPI.jl
@@ -73,17 +73,20 @@ function __init__()
     precompiling = ccall(:jl_generating_output, Cint, ()) != 0
     precompiling && return
 
-    if Sys.iswindows()
-        @warn """oneAPI.jl support for native Windows is experimental and incomplete.
+    if oneL0.NEO_jll.is_available() && oneL0.functional[]
+        if Sys.iswindows()
+            @warn """oneAPI.jl support for native Windows is experimental and incomplete.
                  For the time being, it is recommended to use WSL or Linux instead."""
-    else
-        # ensure that the OpenCL loader finds the ICD files from our artifacts
-        ENV["OCL_ICD_FILENAMES"] = oneL0.NEO_jll.libigdrcl
-    end
+        else
+            # ensure that the OpenCL loader finds the ICD files from our artifacts
+            ENV["OCL_ICD_FILENAMES"] = oneL0.NEO_jll.libigdrcl
+        end
 
-    # XXX: work around an issue with SYCL/Level Zero interoperability
-    #      (see JuliaGPU/oneAPI.jl#417)
-    ENV["SYCL_PI_LEVEL_ZERO_BATCH_SIZE"] = "1"
+        # XXX: work around an issue with SYCL/Level Zero interoperability
+        #      (see JuliaGPU/oneAPI.jl#417)
+        ENV["SYCL_PI_LEVEL_ZERO_BATCH_SIZE"] = "1"
+    end
+    return nothing
 end
 
 function set_debug!(debug::Bool)


### PR DESCRIPTION
I verified this fixes #489:
```
julia> using oneAPI
┌ Error: No oneAPI Level Zero loader found for your platform. Currently, only Linux x86 is supported.
│ If you have a local oneAPI toolchain, you can use that; refer to the documentation for more details.
└ @ oneAPI.oneL0 ~/.julia/packages/oneAPI/8uwwt/lib/level-zero/oneL0.jl:118

julia> 
```
The message is only an `@error` logging, but the session is otherwise fully functional.

CC: @vchuravy.  PR best reviewed by [ignoring whitespace changes](https://github.com/JuliaGPU/oneAPI.jl/pull/493/files?w=1).