### PR TITLE
[CI] Use oneAPI 2025.1.0

### DIFF
--- a/deps/Project.toml
+++ b/deps/Project.toml
@@ -12,4 +12,4 @@ oneAPI_Level_Zero_Headers_jll = "f4bc562b-d309-54f8-9efb-476e56f0410d"
 oneAPI_Support_Headers_jll = "24f86df5-245d-5634-a4cc-32433d9800b3"
 
 [compat]
-oneAPI_Support_Headers_jll = "=2025.0.0"
+oneAPI_Support_Headers_jll = "=2025.1.0"

--- a/deps/Project.toml
+++ b/deps/Project.toml
@@ -12,4 +12,4 @@ oneAPI_Level_Zero_Headers_jll = "f4bc562b-d309-54f8-9efb-476e56f0410d"
 oneAPI_Support_Headers_jll = "24f86df5-245d-5634-a4cc-32433d9800b3"
 
 [compat]
-oneAPI_Support_Headers_jll = "=2025.1.0"
+oneAPI_Support_Headers_jll = "=2025.0.0, =2025.1.0"

--- a/deps/Project.toml
+++ b/deps/Project.toml
@@ -12,4 +12,4 @@ oneAPI_Level_Zero_Headers_jll = "f4bc562b-d309-54f8-9efb-476e56f0410d"
 oneAPI_Support_Headers_jll = "24f86df5-245d-5634-a4cc-32433d9800b3"
 
 [compat]
-oneAPI_Support_Headers_jll = "=2025.0.0, =2025.1.0"
+oneAPI_Support_Headers_jll = "=2025.1.0"

--- a/deps/build_local.jl
+++ b/deps/build_local.jl
@@ -45,7 +45,7 @@ if !isfile(joinpath(conda_dir, "condarc-julia.yml"))
     touch(joinpath(conda_dir, "conda-meta", "history"))
 end
 Conda.add_channel("https://software.repos.intel.com/python/conda/", conda_dir)
-Conda.add(["dpcpp_linux-64=2025.0.0", "mkl-devel-dpcpp=2025.0.0"], conda_dir)
+Conda.add(["dpcpp_linux-64=2025.1.0", "mkl-devel-dpcpp=2025.1.0"], conda_dir)
 
 Conda.list(conda_dir)
 


### PR DESCRIPTION
Intel didn't added any routines in oneAPI 2025.1.0.
I checked with a local build of: https://github.com/JuliaPackaging/Yggdrasil/pull/11015

No issue to compile the `liboneapi_support.so` with the new version of the compiler, let's see if we have an issue with CI.

cc @michel2323