### PR TITLE
Add a function oneMKL.version()

### DIFF
--- a/deps/generate_interfaces.jl
+++ b/deps/generate_interfaces.jl
@@ -492,6 +492,12 @@ headers_epilogue = read("onemkl_epilogue.h", String)
 write(io, headers_epilogue)
 close(io)
 
+# Add the version of oneMKL in src/onemkl.h
+headers_onemkl = read("src/onemkl.h", String)
+version_onemkl = pkgversion(oneAPI_Support_Headers_jll)
+headers_onemkl = replace(headers_onemkl, "void onemkl_version" => "const int64_t ONEMKL_VERSION_MAJOR = $(version_onemkl.major);\nconst int64_t ONEMKL_VERSION_MINOR = $(version_onemkl.minor);\nconst int64_t ONEMKL_VERSION_PATCH = $(version_onemkl.patch);\nvoid onemkl_version")
+write("src/onemkl.h", headers_onemkl)
+
 # Generate "src/onemkl.cpp"
 generate_cpp("blas", blas, "onemkl_blas.cpp", pattern="§")
 generate_cpp("lapack", lapack, "onemkl_lapack.cpp", pattern="§")

--- a/deps/onemkl_prologue.cpp
+++ b/deps/onemkl_prologue.cpp
@@ -280,6 +280,14 @@ oneapi::mkl::sparse::omatadd_alg convert(onemklOmataddAlg val) {
     }
 }
 
+// version
+extern "C" void onemkl_version(int64_t *major, int64_t *minor, int64_t *patch) {
+    *major = ONEMKL_VERSION_MAJOR;
+    *minor = ONEMKL_VERSION_MINOR;
+    *patch = ONEMKL_VERSION_PATCH;
+    return;
+}
+
 // gemm
 // https://spec.oneapi.io/versions/1.0-rev-1/elements/oneMKL/source/domains/blas/gemm.html
 class gemmBatchInfo {

--- a/deps/onemkl_prologue.h
+++ b/deps/onemkl_prologue.h
@@ -140,6 +140,8 @@ typedef struct omatconvert_descr *omatconvert_descr_t;
 struct omatadd_descr;
 typedef struct omatadd_descr *omatadd_descr_t;
 
+void onemkl_version(int64_t *major, int64_t *minor, int64_t *patch);
+
 int onemklHgemm_batch(syclQueue_t device_queue, onemklTranspose transa,
                       onemklTranspose transb, int64_t *m,
                       int64_t *n, int64_t *k, uint16_t *alpha,

--- a/deps/src/onemkl.cpp
+++ b/deps/src/onemkl.cpp
@@ -280,6 +280,14 @@ oneapi::mkl::sparse::omatadd_alg convert(onemklOmataddAlg val) {
     }
 }
 
+// version
+extern "C" void onemkl_version(int64_t *major, int64_t *minor, int64_t *patch) {
+    *major = ONEMKL_VERSION_MAJOR;
+    *minor = ONEMKL_VERSION_MINOR;
+    *patch = ONEMKL_VERSION_PATCH;
+    return;
+}
+
 // gemm
 // https://spec.oneapi.io/versions/1.0-rev-1/elements/oneMKL/source/domains/blas/gemm.html
 class gemmBatchInfo {

--- a/deps/src/onemkl.h
+++ b/deps/src/onemkl.h
@@ -140,6 +140,11 @@ typedef struct omatconvert_descr *omatconvert_descr_t;
 struct omatadd_descr;
 typedef struct omatadd_descr *omatadd_descr_t;
 
+const int64_t ONEMKL_VERSION_MAJOR = 2025;
+const int64_t ONEMKL_VERSION_MINOR = 2;
+const int64_t ONEMKL_VERSION_PATCH = 0;
+void onemkl_version(int64_t *major, int64_t *minor, int64_t *patch);
+
 int onemklHgemm_batch(syclQueue_t device_queue, onemklTranspose transa,
                       onemklTranspose transb, int64_t *m,
                       int64_t *n, int64_t *k, uint16_t *alpha,

--- a/lib/level-zero/libze.jl
+++ b/lib/level-zero/libze.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 # outlined functionality to avoid GC frame allocation
 @noinline function throw_api_error(res)

--- a/lib/mkl/oneMKL.jl
+++ b/lib/mkl/oneMKL.jl
@@ -31,6 +31,14 @@ include("linalg.jl")
 include("interfaces.jl")
 include("fft.jl")
 
+function version()
+    major = Ref{Int64}()
+    minor = Ref{Int64}()
+    patch = Ref{Int64}()
+    onemkl_version(major, minor, patch)
+    return VersionNumber(major[], minor[], patch[])
+end
+
 function band(A::StridedArray, kl, ku)
     m, n = size(A)
     AB = zeros(eltype(A),kl+ku+1,n)

--- a/lib/support/liboneapi_support.jl
+++ b/lib/support/liboneapi_support.jl
@@ -1,4 +1,4 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 mutable struct syclPlatform_st end
 
@@ -203,6 +203,11 @@ const omatconvert_descr_t = Ptr{omatconvert_descr}
 mutable struct omatadd_descr end
 
 const omatadd_descr_t = Ptr{omatadd_descr}
+
+function onemkl_version(major, minor, patch)
+    @ccall liboneapi_support.onemkl_version(major::Ptr{Int64}, minor::Ptr{Int64},
+                                            patch::Ptr{Int64})::Cvoid
+end
 
 function onemklHgemm_batch(device_queue, transa, transb, m, n, k, alpha, a, lda, b, ldb,
                            beta, c, ldc, group_count, group_size)

--- a/test/onemkl.jl
+++ b/test/onemkl.jl
@@ -12,6 +12,11 @@ m = 20
 n = 35
 k = 13
 
+@testset "Version" begin
+    version_onemkl = oneMKL.version()
+    @test version_onemkl ≥ v"2025.2.0"
+end
+
 ############################################################################################
 @testset "level 1" begin
     @testset for T in intersect(eltypes, [Float32, Float64, ComplexF32, ComplexF64])


### PR DESCRIPTION
#525 

@michel2323 
I didn't updated `oneAPI.versioninfo()`, can you do it after the PR?
