### PR TITLE
Fix bitrotted local builds of the support library

### DIFF
--- a/deps/build_ci.jl
+++ b/deps/build_ci.jl
@@ -1,4 +1,16 @@
 using Pkg
+
+# Conda.jl fails to precompile when its root environment directory has been removed
+# (e.g., by depot clean-up) while its deps.jl still points to it. Pre-create the
+# directory so that precompilation succeeds; Conda lazily re-installs itself on use.
+let deps_jl = joinpath(first(DEPOT_PATH), "conda", "deps.jl")
+    if isfile(deps_jl)
+        mod = Module()
+        Base.include(mod, deps_jl)
+        isdefined(mod, :ROOTENV) && mkpath(mod.ROOTENV)
+    end
+end
+
 Pkg.activate(@__DIR__)
 Pkg.instantiate()
 

--- a/deps/build_local.jl
+++ b/deps/build_local.jl
@@ -1,6 +1,18 @@
 # build liboneapi_support with C wrappers for C++ APIs
 
 using Pkg
+
+# Conda.jl fails to precompile when its root environment directory has been removed
+# (e.g., by depot clean-up) while its deps.jl still points to it. Pre-create the
+# directory so that precompilation succeeds; Conda lazily re-installs itself on use.
+let deps_jl = joinpath(first(DEPOT_PATH), "conda", "deps.jl")
+    if isfile(deps_jl)
+        mod = Module()
+        Base.include(mod, deps_jl)
+        isdefined(mod, :ROOTENV) && mkpath(mod.ROOTENV)
+    end
+end
+
 Pkg.activate(@__DIR__)
 Pkg.instantiate()
 
@@ -38,6 +50,11 @@ if !isdir(Conda.ROOTENV)
     # Same as above
     Pkg.build("Conda")
 end
+
+# make sure the CA roots used by conda's Python are up-to-date, as outdated certificates
+# otherwise result in SSL verification errors when accessing Intel's package repository
+Conda.add(["ca-certificates", "certifi"], Conda.ROOTENV)
+
 if !isfile(joinpath(conda_dir, "condarc-julia.yml"))
     Conda.create(conda_dir)
     # conda#8850


### PR DESCRIPTION
The local build of `liboneapi_support` (as triggered by `deps/build_ci.jl` on CI when the wrappers are newer than the latest `oneAPI_Support_jll` build) had bitrotted in two ways:

- **Conda.jl precompilation failure**: when the Conda root environment directory has been removed (e.g., by depot clean-up on CI agents) while Conda.jl's `deps.jl` still points to it, precompilation fails with `ArgumentError: Path to conda environment is not valid`, because `Conda.prefix(ROOTENV)` runs at module top level. We now pre-create the directory before instantiating; Conda lazily re-installs itself on first use anyway.

- **SSL certificate verification failure**: old Conda root environments ship a `certifi` CA bundle (e.g., 2022.06.15) that cannot validate the Sectigo certificate chain currently served by `software.repos.intel.com`, so every `conda install` from the Intel channel fails with `CERTIFICATE_VERIFY_FAILED`. We now update `ca-certificates`/`certifi` in the root environment before installing the toolchain.

With these changes, `deps/build_ci.jl` again builds the support library end-to-end locally (dpcpp/MKL 2025.2.0, only deprecation warnings during compilation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)