### PR TITLE
Make floating-point atomics work on the LLVM back-end path

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -56,8 +56,3 @@ oneAPI_Support_jll = "0.10.0"
 
 [extras]
 libigc_jll = "94295238-5935-5bd7-bb0f-b00942e9bdd5"
-
-[sources]
-# Pin to a commit SHA, not the mutable `atomic-float-ops` branch head, so builds are
-# reproducible and a force-push upstream cannot silently change what users resolve.
-SPIRVIntrinsics = {url = "https://github.com/JuliaGPU/OpenCL.jl", rev = "main", subdir = "lib/intrinsics"}

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "oneAPI"
 uuid = "8f75cd03-7ff8-4ecb-9b8f-daf728133b1b"
 authors = ["Tim Besard <tim.besard@gmail.com>", "Alexis Montoison", "Michel Schanen <michel.schanen@gmail.com>"]
-version = "2.7.2"
+version = "2.7.3"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/Project.toml
+++ b/Project.toml
@@ -60,4 +60,4 @@ libigc_jll = "94295238-5935-5bd7-bb0f-b00942e9bdd5"
 [sources]
 # Pin to a commit SHA, not the mutable `atomic-float-ops` branch head, so builds are
 # reproducible and a force-push upstream cannot silently change what users resolve.
-SPIRVIntrinsics = {url = "https://github.com/michel2323/OpenCL.jl", rev = "4257d4075162276d9985168923788490e4071e9e", subdir = "lib/intrinsics"}
+SPIRVIntrinsics = {url = "https://github.com/JuliaGPU/OpenCL.jl", rev = "main", subdir = "lib/intrinsics"}

--- a/Project.toml
+++ b/Project.toml
@@ -56,3 +56,8 @@ oneAPI_Support_jll = "0.10.0"
 
 [extras]
 libigc_jll = "94295238-5935-5bd7-bb0f-b00942e9bdd5"
+
+[sources]
+# Pin to a commit SHA, not the mutable `atomic-float-ops` branch head, so builds are
+# reproducible and a force-push upstream cannot silently change what users resolve.
+SPIRVIntrinsics = {url = "https://github.com/michel2323/OpenCL.jl", rev = "4257d4075162276d9985168923788490e4071e9e", subdir = "lib/intrinsics"}

--- a/src/compiler/compilation.jl
+++ b/src/compiler/compilation.jl
@@ -328,7 +328,14 @@ end
     # advertise the extension). We lower bfloat→i16 in finish_ir! when needed.
     supports_bfloat16 = _device_supports_bfloat16(dev)
 
-    extensions = String[]
+    # SPIR-V extensions the LLVM back-end may emit. Declaring them permits the
+    # corresponding instructions during translation: without
+    # SPV_EXT_shader_atomic_float_add, floating-point atomic operations fail to
+    # translate ("The atomic float instruction requires ... SPV_EXT_shader_atomic_float_add").
+    extensions = String[
+        "SPV_EXT_relaxed_printf_string_address_space",
+        "SPV_EXT_shader_atomic_float_add",
+    ]
     # Only add the SPIR-V extension if the runtime actually supports it
     if _driver_supports_bfloat16_spirv(dev)
         push!(extensions, "SPV_KHR_bfloat16")


### PR DESCRIPTION
On discrete GPUs (tested on an Arc A750, NEO 26.18), `oneAPI.atomic_add!`/`atomic_sub!` on `Float32` fail with 4 errors in `device/intrinsics`: the atomic intrinsics fall back to an unsupported runtime call (`unsupported call to an unknown function (call to gpu_malloc)`). Two changes fix this:

- pin SPIRVIntrinsics to the `atomic-float-ops` revision, whose atomic intrinsics lower properly (pinned by commit SHA so the resolution is reproducible);
- declare `SPV_EXT_shader_atomic_float_add` (plus the relaxed-printf extension) for the LLVM SPIR-V back-end — extensions must be declared to permit the corresponding instructions during translation, and without the declaration the atomic float instructions fail with `LLVM ERROR: The atomic float instruction requires the following SPIR-V extension: SPV_EXT_shader_atomic_float_add`.

Also relaxes the onemkl version test to accept oneMKL 2025.2+, so the suite works against a locally built support library (and the Aurora LTS toolchain, where this originates).

With this, `device/intrinsics` passes 116/116 and `onemkl` 1048 + 48 broken on the A750. Extracted from the aurora-lts branch so it can land on main independently.