### PR TITLE
Point branch references at main instead of master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
     tags: '*'
   pull_request:
     types: [opened, synchronize, reopened]

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: Documentation
 on:
   push:
     branches:
-      - master
+      - main
     tags: '*'
   pull_request:
     types: [opened, synchronize, reopened]

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 [doi-img]: https://zenodo.org/badge/252466420.svg
 [doi-url]: https://zenodo.org/badge/latestdoi/252466420
 
-[buildkite-img]: https://badge.buildkite.com/00fff01fd4d6cdd905e61e2ce7ed0f7203ba227df9b575426c.svg?branch=master
+[buildkite-img]: https://badge.buildkite.com/00fff01fd4d6cdd905e61e2ce7ed0f7203ba227df9b575426c.svg?branch=main
 [buildkite-url]: https://buildkite.com/julialang/oneapi-dot-jl
 
-[codecov-img]: https://codecov.io/gh/JuliaGPU/oneAPI.jl/branch/master/graph/badge.svg
+[codecov-img]: https://codecov.io/gh/JuliaGPU/oneAPI.jl/branch/main/graph/badge.svg
 [codecov-url]: https://codecov.io/gh/JuliaGPU/oneAPI.jl
 
 [docs-stable-img]: https://img.shields.io/badge/docs-stable-blue.svg

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -47,7 +47,7 @@ makedocs(
 deploydocs(
     repo = "github.com/JuliaGPU/oneAPI.jl.git",
     target = "build",
-    devbranch = "master",
+    devbranch = "main",
     devurl = "dev",
     push_preview = true,
 )


### PR DESCRIPTION
The default branch was renamed `master` -> `main` between 2026-05-16 02:26 UTC and 2026-05-17 02:30 UTC, but the in-repo references to it were never updated. Four of them are still stale.

### Buildkite badge (`README.md`)

The badge requested `?branch=master`, so Buildkite rendered the last build that branch ever saw — a stale failure — even though `main` is green:

| badge URL | renders |
| --- | --- |
| `…svg?branch=master` (before) | `failing` |
| `…svg?branch=main` (after) | `passing` |

### Codecov badge (`README.md`)

Same failure mode: pinned to `/branch/master/`, which no longer receives coverage uploads.

### CI and Documentation workflows

`.github/workflows/{ci,docs}.yml` trigger on `push: branches: [master]`. Since that branch no longer exists, **neither workflow has run on a push to the default branch since the rename** — only `pull_request` and scheduled runs were still firing.

Note that this fix only takes effect once merged, since GitHub reads `on:` from the branch being pushed.

### Documenter

`docs/make.jl` had `devbranch = "master"`, so the `dev` docs were not being deployed from `main`.

---

For reference, `.github/workflows/Format.yml` also contains `master`, but that is part of an upstream Runic.jl raw URL and is intentionally left alone.
