### PR TITLE
Build against oneMKL 2025.3.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "oneAPI"
 uuid = "8f75cd03-7ff8-4ecb-9b8f-daf728133b1b"
 authors = ["Tim Besard <tim.besard@gmail.com>", "Alexis Montoison", "Michel Schanen <michel.schanen@gmail.com>"]
-version = "2.7.1"
+version = "2.7.2"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/deps/Project.toml
+++ b/deps/Project.toml
@@ -12,4 +12,4 @@ oneAPI_Level_Zero_Headers_jll = "f4bc562b-d309-54f8-9efb-476e56f0410d"
 oneAPI_Support_Headers_jll = "24f86df5-245d-5634-a4cc-32433d9800b3"
 
 [compat]
-oneAPI_Support_Headers_jll = "=2025.2.0"
+oneAPI_Support_Headers_jll = "=2025.3.1"

--- a/deps/build_local.jl
+++ b/deps/build_local.jl
@@ -21,11 +21,16 @@ if haskey(ENV, "BUILDKITE")
 end
 
 using Scratch, Preferences, CMake_jll, Ninja_jll, oneAPI_Level_Zero_Headers_jll
+import oneAPI_Support_Headers_jll
 
 oneAPI = Base.UUID("8f75cd03-7ff8-4ecb-9b8f-daf728133b1b")
 
+# the Conda toolkit version tracks the headers JLL the wrappers were generated from
+headers_version = pkgversion(oneAPI_Support_Headers_jll)
+toolkit = "$(headers_version.major).$(headers_version.minor).$(headers_version.patch)"
+
 # get scratch directories
-conda_dir = get_scratch!(oneAPI, "conda")
+conda_dir = get_scratch!(oneAPI, "conda-$toolkit")
 install_dir = get_scratch!(oneAPI, "deps")
 rm(install_dir; recursive=true)
 
@@ -62,7 +67,7 @@ if !isfile(joinpath(conda_dir, "condarc-julia.yml"))
     touch(joinpath(conda_dir, "conda-meta", "history"))
 end
 Conda.add_channel("https://software.repos.intel.com/python/conda/", conda_dir)
-Conda.add(["dpcpp_linux-64=2026.0.0", "mkl-devel-dpcpp=2026.0.0"], conda_dir)
+Conda.add(["dpcpp_linux-64=$toolkit", "mkl-devel-dpcpp=$toolkit"], conda_dir)
 
 Conda.list(conda_dir)
 

--- a/deps/generate_interfaces.jl
+++ b/deps/generate_interfaces.jl
@@ -1,14 +1,22 @@
-using oneAPI_Support_Headers_jll
+# The wrappers are generated from the oneMKL headers pinned in Project.toml (2025.3.1,
+# the oneAPI toolkit shared by the Intel GPU LTS stack and, API-wise, the 2026.x rolling
+# releases): the sparse setters use the wide ABI (64-bit dims, explicit nnz) introduced
+# there, so the generated sources require oneMKL 2025.3 or newer to build.
+import oneAPI_Support_Headers_jll
 
 include("generate_helpers.jl")
 
+function mkl_header_files(include_dir)
+  blas = [joinpath(include_dir, "oneapi", "mkl", "blas", "buffer_decls.hpp")]
+  lapack = [joinpath(include_dir, "oneapi", "mkl", "lapack", "lapack.hpp"),
+            joinpath(include_dir, "oneapi", "mkl", "lapack", "scratchpad.hpp")]
+  sparse = [joinpath(include_dir, "oneapi", "mkl", "spblas", "sparse_structures.hpp"),
+            joinpath(include_dir, "oneapi", "mkl", "spblas", "sparse_auxiliary.hpp"),
+            joinpath(include_dir, "oneapi", "mkl", "spblas", "sparse_operations.hpp")]
+  return Dict("blas" => blas, "lapack" => lapack, "sparse" => sparse)
+end
+
 include_dir = joinpath(oneAPI_Support_Headers_jll.artifact_dir, "include")
-blas = [joinpath(include_dir, "oneapi", "mkl", "blas", "buffer_decls.hpp")]
-lapack = [joinpath(include_dir, "oneapi", "mkl", "lapack", "lapack.hpp"),
-          joinpath(include_dir, "oneapi", "mkl", "lapack", "scratchpad.hpp")]
-sparse = [joinpath(include_dir, "oneapi", "mkl", "spblas", "sparse_structures.hpp"),
-          joinpath(include_dir, "oneapi", "mkl", "spblas", "sparse_auxiliary.hpp"),
-          joinpath(include_dir, "oneapi", "mkl", "spblas", "sparse_operations.hpp")]
 
 dict_version = Dict{Int, Char}(1 => 'S', 2 => 'D', 3 => 'C', 4 => 'Z')
 
@@ -27,7 +35,7 @@ comments = ["namespace", "#", "}", "/*", "*", "//", "[[", "ONEMKL_DECLARE_", "ON
 void_output = ["init_matrix_handle", "init_matmat_descr", "release_matmat_descr", "set_matmat_data",
                "get_matmat_data", "init_omatadd_descr", "init_omatconvert_descr"]
 
-function generate_headers(library::String, filename::Vector{String}, output::String; pattern::String="")
+function generate_headers(library::String, filename::Vector{String}; pattern::String="")
   routines = Dict{String,Int}()
   signatures = []
   signatures2 = []
@@ -37,6 +45,9 @@ function generate_headers(library::String, filename::Vector{String}, output::Str
   end
   cpp_headers = replace(cpp_headers, "std::int32_t" => "int32_t")
   cpp_headers = replace(cpp_headers, "std::int64_t" => "int64_t")
+  # the sparse headers are inconsistent about the handle parameter name across versions
+  # (spMat/spmat); normalize so identical functions compare equal across header sets
+  cpp_headers = replace(cpp_headers, "spMat" => "spmat")
   cpp_headers = replace(cpp_headers, "; \\" => ";")
   cpp_headers = replace(cpp_headers, ")\n\n" => ");\n\n")
   cpp_headers = replace(cpp_headers, "\\\n" => "\n")
@@ -337,12 +348,31 @@ function generate_headers(library::String, filename::Vector{String}, output::Str
     end
   end
 
-  path_oneapi_headers = joinpath(@__DIR__, output)
-  oneapi_headers = open(path_oneapi_headers, "w")
+  # Dedup: when two signatures map to the same C function name (because MKL
+  # added an overload), keep the one with more parameters — typically the
+  # newer signature (e.g. set_csr_data gained an `nnz` arg in MKL 2025.3.1).
+  # Without this the generated onemkl.cpp has duplicate function definitions
+  # and won't compile.
+  _fn_name(h) = (pos = findfirst('(', h); strip(split(strip(h[1:pos-1]))[end]))
+  _param_cnt(h) = (pos = findfirst('(', h); ep = findnext(')', h, pos); count(==(','), h[pos+1:ep-1]) + 1)
+  keep_idx = Dict{String,Int}()
+  keep_pc  = Dict{String,Int}()
+  for (i, sig) in enumerate(signatures)
+    (sig[2] in blacklist) && continue
+    fn = _fn_name(sig[1])
+    pc = _param_cnt(sig[1])
+    if !haskey(keep_idx, fn) || pc > keep_pc[fn]
+      keep_idx[fn] = i
+      keep_pc[fn]  = pc
+    end
+  end
+  keep_set = Set(values(keep_idx))
 
-  for (header, name_routine, version, type_routine, template) in signatures
+  for (i, (header, name_routine, version, type_routine, template)) in enumerate(signatures)
     # Blacklist
     (name_routine in blacklist) && continue
+    # Dedup
+    (i in keep_set) || continue
 
     # Pass scalars (e.g. alpha/beta inputs) as references instead of values
     for type in ("short", "float", "double", "float _Complex", "double _Complex")
@@ -351,35 +381,38 @@ function generate_headers(library::String, filename::Vector{String}, output::Str
     end
 
     push!(signatures2, (header, name_routine, version, type_routine, template))
-
-    pos = findfirst('(', header)
-    fun = split(header, " ")
-    len = 0
-    for (i, part) in enumerate(fun)
-      len += length(part)
-      if len ≤ 90
-        (i ≠ 1) && write(oneapi_headers, " ")
-        write(oneapi_headers, part)
-      else
-        write(oneapi_headers, "\n")
-        for i = 1:pos
-          write(oneapi_headers, " ")
-        end
-        write(oneapi_headers, part)
-        len = pos + length(part)
-      end
-    end
-    write(oneapi_headers, ";\n\n")
   end
-  close(oneapi_headers)
   return signatures2
 end
 
-function generate_cpp(library::String, filename::Vector{String}, output::String; pattern::String="")
-  signatures = generate_headers(library, filename, output; pattern)
-  path_oneapi_cpp = joinpath(@__DIR__, output)
-  oneapi_cpp = open(path_oneapi_cpp, "w")
-  for (header, name, version, type_routine, template) in signatures
+# Format a single-line C signature as a declaration wrapped at ~90 columns
+function format_decl(header)
+  io = IOBuffer()
+  pos = findfirst('(', header)
+  fun = split(header, " ")
+  len = 0
+  for (i, part) in enumerate(fun)
+    len += length(part)
+    if len ≤ 90
+      (i ≠ 1) && write(io, " ")
+      write(io, part)
+    else
+      write(io, "\n")
+      for i = 1:pos
+        write(io, " ")
+      end
+      write(io, part)
+      len = pos + length(part)
+    end
+  end
+  write(io, ";\n\n")
+  return String(take!(io))
+end
+
+# Turn one parsed signature into the C function signature and the implementation body
+# (the text between the braces), so the caller can compose plain or version-guarded
+# definitions.
+function cpp_wrapper(header, name, version, type_routine, template, library)
     parameters = split(header, "(")[2]
     parameters = split(parameters, ")")[1]
     parameters = replace(parameters, "syclQueue_t device_queue" => "device_queue->val")
@@ -448,18 +481,18 @@ function generate_cpp(library::String, filename::Vector{String}, output::String;
     lapack_catch = "catch (const oneapi::mkl::lapack::computation_error& e) { return e.info(); } catch (const sycl::exception& e) { return -1; }"
     sycl_catch = "catch (const sycl::exception& e) { return -1; }"
 
-    write(oneapi_cpp, "extern \"C\" $header {\n")
+    body = IOBuffer()
     if template
       type = version_types[version]
       if !occursin("scratchpad_size", name)
         catch_clause = library == "lapack" ? lapack_catch : sycl_catch
-        write(oneapi_cpp, "   try {\n")
-        write(oneapi_cpp, "      auto status = oneapi::mkl::$library::$variant$name<$type>($parameters, {});\n")
-        write(oneapi_cpp, "      device_queue->val.wait_and_throw();\n")
-        write(oneapi_cpp, "   } $catch_clause\n")
+        write(body, "   try {\n")
+        write(body, "      auto status = oneapi::mkl::$library::$variant$name<$type>($parameters, {});\n")
+        write(body, "      device_queue->val.wait_and_throw();\n")
+        write(body, "   } $catch_clause\n")
       end
       if occursin("scratchpad_size", name)
-        write(oneapi_cpp, "   int64_t scratchpad_size = oneapi::mkl::$library::$variant$name<$type>($parameters);\n   device_queue->val.wait_and_throw();\n")
+        write(body, "   int64_t scratchpad_size = oneapi::mkl::$library::$variant$name<$type>($parameters);\n   device_queue->val.wait_and_throw();\n")
       end
     else
       if !(name ∈ void_output)
@@ -467,82 +500,73 @@ function generate_cpp(library::String, filename::Vector{String}, output::String;
         is_scratchpad = occursin("scratchpad_size", name)
         if has_queue && !is_scratchpad
           catch_clause = library == "lapack" ? lapack_catch : sycl_catch
-          write(oneapi_cpp, "   try {\n")
-          write(oneapi_cpp, "      auto status = oneapi::mkl::$library::$variant$name($parameters, {});\n")
-          write(oneapi_cpp, "      device_queue->val.wait_and_throw();\n")
-          write(oneapi_cpp, "   } $catch_clause\n")
+          write(body, "   try {\n")
+          write(body, "      auto status = oneapi::mkl::$library::$variant$name($parameters, {});\n")
+          write(body, "      device_queue->val.wait_and_throw();\n")
+          write(body, "   } $catch_clause\n")
         else
-          write(oneapi_cpp, "   auto status = oneapi::mkl::$library::$variant$name($parameters, {});\n")
+          write(body, "   auto status = oneapi::mkl::$library::$variant$name($parameters, {});\n")
           if has_queue
-            write(oneapi_cpp, "   device_queue->val.wait_and_throw();\n")
+            write(body, "   device_queue->val.wait_and_throw();\n")
           end
         end
       else
         if occursin("device_queue", parameters)
-          write(oneapi_cpp, "   try {\n")
-          write(oneapi_cpp, "      oneapi::mkl::$library::$variant$name($parameters);\n")
-          write(oneapi_cpp, "      device_queue->val.wait_and_throw();\n")
-          write(oneapi_cpp, "   } $sycl_catch\n")
+          write(body, "   try {\n")
+          write(body, "      oneapi::mkl::$library::$variant$name($parameters);\n")
+          write(body, "      device_queue->val.wait_and_throw();\n")
+          write(body, "   } $sycl_catch\n")
         else
-          write(oneapi_cpp, "   oneapi::mkl::$library::$variant$name($parameters);\n")
+          write(body, "   oneapi::mkl::$library::$variant$name($parameters);\n")
         end
       end
     end
     if occursin("scratchpad_size", name)
-      write(oneapi_cpp, "   return scratchpad_size;\n")
+      write(body, "   return scratchpad_size;\n")
     else
-      write(oneapi_cpp, "   return 0;\n")
+      write(body, "   return 0;\n")
     end
-    write(oneapi_cpp, "}")
-    write(oneapi_cpp, "\n\n")
+    return header, String(take!(body))
+end
+
+# Parse one library and emit the C declarations and implementations
+function sources(library, files)
+  hsigs = generate_headers(library, files; pattern="*")
+  csigs = generate_headers(library, files; pattern="§")
+  @assert length(hsigs) == length(csigs)
+
+  decls = IOBuffer()
+  impls = IOBuffer()
+  for (hsig, csig) in zip(hsigs, csigs)
+    write(decls, format_decl(hsig[1]))
+    chdr, body = cpp_wrapper(csig..., library)
+    write(impls, "extern \"C\" $chdr {\n$body}\n\n")
   end
-  close(oneapi_cpp)
+  return String(take!(decls)), String(take!(impls))
+end
+
+files = mkl_header_files(include_dir)
+
+decls = Dict{String,String}()
+impls = Dict{String,String}()
+for library in ("blas", "lapack", "sparse")
+  decls[library], impls[library] = sources(library, files[library])
 end
 
 # Generate "src/onemkl.h"
-generate_headers("blas", blas, "onemkl_blas.h", pattern="*")
-generate_headers("lapack", lapack, "onemkl_lapack.h", pattern="*")
-generate_headers("sparse", sparse, "onemkl_sparse.h", pattern="*")
-
-io = open("src/onemkl.h", "w")
-headers_prologue = read("onemkl_prologue.h", String)
-write(io, headers_prologue)
-headers_blas = read("onemkl_blas.h", String)
-write(io, "// BLAS\n")
-write(io, headers_blas)
-headers_lapack = read("onemkl_lapack.h", String)
-write(io, "// LAPACK\n")
-write(io, headers_lapack)
-headers_sparse = read("onemkl_sparse.h", String)
-write(io, "// SPARSE\n")
-write(io, headers_sparse)
-headers_epilogue = read("onemkl_epilogue.h", String)
-write(io, headers_epilogue)
-close(io)
-
-# Add the version of oneMKL in src/onemkl.h
-headers_onemkl = read("src/onemkl.h", String)
-version_onemkl = pkgversion(oneAPI_Support_Headers_jll)
-headers_onemkl = replace(headers_onemkl, "void onemkl_version" => "const int64_t ONEMKL_VERSION_MAJOR = $(version_onemkl.major);\nconst int64_t ONEMKL_VERSION_MINOR = $(version_onemkl.minor);\nconst int64_t ONEMKL_VERSION_PATCH = $(version_onemkl.patch);\nvoid onemkl_version")
-write("src/onemkl.h", headers_onemkl)
+open(joinpath(@__DIR__, "src", "onemkl.h"), "w") do io
+  write(io, read(joinpath(@__DIR__, "onemkl_prologue.h"), String))
+  write(io, "// BLAS\n", decls["blas"])
+  write(io, "// LAPACK\n", decls["lapack"])
+  write(io, "// SPARSE\n", decls["sparse"])
+  write(io, read(joinpath(@__DIR__, "onemkl_epilogue.h"), String))
+end
 
 # Generate "src/onemkl.cpp"
-generate_cpp("blas", blas, "onemkl_blas.cpp", pattern="§")
-generate_cpp("lapack", lapack, "onemkl_lapack.cpp", pattern="§")
-generate_cpp("sparse", sparse, "onemkl_sparse.cpp", pattern="§")
-
-io = open("src/onemkl.cpp", "w")
-cpp_prologue = read("onemkl_prologue.cpp", String)
-write(io, cpp_prologue)
-cpp_blas = read("onemkl_blas.cpp", String)
-write(io, "// BLAS\n")
-write(io, cpp_blas)
-cpp_lapack = read("onemkl_lapack.cpp", String)
-write(io, "// LAPACK\n")
-write(io, cpp_lapack)
-cpp_sparse = read("onemkl_sparse.cpp", String)
-write(io, "// SPARSE\n")
-write(io, cpp_sparse)
-cpp_epilogue = read("onemkl_epilogue.cpp", String)
-write(io, cpp_epilogue)
-close(io)
+open(joinpath(@__DIR__, "src", "onemkl.cpp"), "w") do io
+  write(io, read(joinpath(@__DIR__, "onemkl_prologue.cpp"), String))
+  write(io, "// BLAS\n", impls["blas"])
+  write(io, "// LAPACK\n", impls["lapack"])
+  write(io, "// SPARSE\n", impls["sparse"])
+  write(io, read(joinpath(@__DIR__, "onemkl_epilogue.cpp"), String))
+end

--- a/deps/onemkl_prologue.cpp
+++ b/deps/onemkl_prologue.cpp
@@ -4,6 +4,7 @@
 #include <exception>
 #include <memory>
 #include <oneapi/mkl.hpp>
+#include <mkl_version.h>
 
 oneapi::mkl::transpose convert(onemklTranspose val) {
     switch (val) {
@@ -280,11 +281,13 @@ oneapi::mkl::sparse::omatadd_alg convert(onemklOmataddAlg val) {
     }
 }
 
-// version
+// version of the oneMKL toolkit this library was built against. The product minor is
+// __INTEL_MKL_UPDATE__ (e.g. INTEL_MKL_VERSION 20250300 is the 2025.3 product); the
+// packaging patch level (2025.3.1's ".1") is not exposed by the headers and reports as 0.
 extern "C" void onemkl_version(int64_t *major, int64_t *minor, int64_t *patch) {
-    *major = ONEMKL_VERSION_MAJOR;
-    *minor = ONEMKL_VERSION_MINOR;
-    *patch = ONEMKL_VERSION_PATCH;
+    *major = __INTEL_MKL__;
+    *minor = __INTEL_MKL_UPDATE__;
+    *patch = __INTEL_MKL_PATCH__;
     return;
 }
 

--- a/deps/src/onemkl.cpp
+++ b/deps/src/onemkl.cpp
@@ -4,6 +4,7 @@
 #include <exception>
 #include <memory>
 #include <oneapi/mkl.hpp>
+#include <mkl_version.h>
 
 oneapi::mkl::transpose convert(onemklTranspose val) {
     switch (val) {
@@ -280,11 +281,13 @@ oneapi::mkl::sparse::omatadd_alg convert(onemklOmataddAlg val) {
     }
 }
 
-// version
+// version of the oneMKL toolkit this library was built against. The product minor is
+// __INTEL_MKL_UPDATE__ (e.g. INTEL_MKL_VERSION 20250300 is the 2025.3 product); the
+// packaging patch level (2025.3.1's ".1") is not exposed by the headers and reports as 0.
 extern "C" void onemkl_version(int64_t *major, int64_t *minor, int64_t *patch) {
-    *major = ONEMKL_VERSION_MAJOR;
-    *minor = ONEMKL_VERSION_MINOR;
-    *patch = ONEMKL_VERSION_PATCH;
+    *major = __INTEL_MKL__;
+    *minor = __INTEL_MKL_UPDATE__;
+    *patch = __INTEL_MKL_PATCH__;
     return;
 }
 
@@ -5471,142 +5474,270 @@ extern "C" int64_t onemklZunmqr_batch_scratchpad_size(syclQueue_t device_queue, 
 }
 
 // SPARSE
-extern "C" int onemklXsparse_init_matrix_handle(matrix_handle_t *p_spMat) {
-   oneapi::mkl::sparse::init_matrix_handle((oneapi::mkl::sparse::matrix_handle_t*) p_spMat);
+extern "C" int onemklXsparse_init_matrix_handle(matrix_handle_t *p_spmat) {
+   oneapi::mkl::sparse::init_matrix_handle((oneapi::mkl::sparse::matrix_handle_t*) p_spmat);
    return 0;
 }
 
-extern "C" int onemklXsparse_release_matrix_handle(syclQueue_t device_queue, matrix_handle_t *p_spMat) {
+extern "C" int onemklXsparse_release_matrix_handle(syclQueue_t device_queue, matrix_handle_t *p_spmat) {
    try {
-      auto status = oneapi::mkl::sparse::release_matrix_handle(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t*) p_spMat, {});
+      auto status = oneapi::mkl::sparse::release_matrix_handle(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t*) p_spmat, {});
       device_queue->val.wait_and_throw();
    } catch (const sycl::exception& e) { return -1; }
    return 0;
 }
 
-extern "C" int onemklSsparse_set_csr_data(syclQueue_t device_queue, matrix_handle_t spMat, int32_t nrows, int32_t ncols, onemklIndex index, int32_t *row_ptr, int32_t *col_ind, float *values) {
+extern "C" int onemklSsparse_set_csr_data(syclQueue_t device_queue, matrix_handle_t spmat, int64_t nrows, int64_t ncols, int64_t nnz, onemklIndex index, int32_t *row_ptr, int32_t *col_ind, float *values) {
    try {
-      auto status = oneapi::mkl::sparse::set_csr_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spMat, nrows, ncols, convert(index), row_ptr, col_ind, values, {});
+      auto status = oneapi::mkl::sparse::set_csr_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spmat, nrows, ncols, nnz, convert(index), row_ptr, col_ind, values, {});
       device_queue->val.wait_and_throw();
    } catch (const sycl::exception& e) { return -1; }
    return 0;
 }
 
-extern "C" int onemklSsparse_set_csr_data_64(syclQueue_t device_queue, matrix_handle_t spMat, int64_t nrows, int64_t ncols, onemklIndex index, int64_t *row_ptr, int64_t *col_ind, float *values) {
+extern "C" int onemklSsparse_set_csr_data_64(syclQueue_t device_queue, matrix_handle_t spmat, int64_t nrows, int64_t ncols, int64_t nnz, onemklIndex index, int64_t *row_ptr, int64_t *col_ind, float *values) {
    try {
-      auto status = oneapi::mkl::sparse::set_csr_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spMat, nrows, ncols, convert(index), row_ptr, col_ind, values, {});
+      auto status = oneapi::mkl::sparse::set_csr_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spmat, nrows, ncols, nnz, convert(index), row_ptr, col_ind, values, {});
       device_queue->val.wait_and_throw();
    } catch (const sycl::exception& e) { return -1; }
    return 0;
 }
 
-extern "C" int onemklDsparse_set_csr_data(syclQueue_t device_queue, matrix_handle_t spMat, int32_t nrows, int32_t ncols, onemklIndex index, int32_t *row_ptr, int32_t *col_ind, double *values) {
+extern "C" int onemklDsparse_set_csr_data(syclQueue_t device_queue, matrix_handle_t spmat, int64_t nrows, int64_t ncols, int64_t nnz, onemklIndex index, int32_t *row_ptr, int32_t *col_ind, double *values) {
    try {
-      auto status = oneapi::mkl::sparse::set_csr_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spMat, nrows, ncols, convert(index), row_ptr, col_ind, values, {});
+      auto status = oneapi::mkl::sparse::set_csr_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spmat, nrows, ncols, nnz, convert(index), row_ptr, col_ind, values, {});
       device_queue->val.wait_and_throw();
    } catch (const sycl::exception& e) { return -1; }
    return 0;
 }
 
-extern "C" int onemklDsparse_set_csr_data_64(syclQueue_t device_queue, matrix_handle_t spMat, int64_t nrows, int64_t ncols, onemklIndex index, int64_t *row_ptr, int64_t *col_ind, double *values) {
+extern "C" int onemklDsparse_set_csr_data_64(syclQueue_t device_queue, matrix_handle_t spmat, int64_t nrows, int64_t ncols, int64_t nnz, onemklIndex index, int64_t *row_ptr, int64_t *col_ind, double *values) {
    try {
-      auto status = oneapi::mkl::sparse::set_csr_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spMat, nrows, ncols, convert(index), row_ptr, col_ind, values, {});
+      auto status = oneapi::mkl::sparse::set_csr_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spmat, nrows, ncols, nnz, convert(index), row_ptr, col_ind, values, {});
       device_queue->val.wait_and_throw();
    } catch (const sycl::exception& e) { return -1; }
    return 0;
 }
 
-extern "C" int onemklCsparse_set_csr_data(syclQueue_t device_queue, matrix_handle_t spMat, int32_t nrows, int32_t ncols, onemklIndex index, int32_t *row_ptr, int32_t *col_ind, float _Complex *values) {
+extern "C" int onemklCsparse_set_csr_data(syclQueue_t device_queue, matrix_handle_t spmat, int64_t nrows, int64_t ncols, int64_t nnz, onemklIndex index, int32_t *row_ptr, int32_t *col_ind, float _Complex *values) {
    try {
-      auto status = oneapi::mkl::sparse::set_csr_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spMat, nrows, ncols, convert(index), row_ptr, col_ind, reinterpret_cast<std::complex<float>*>(values), {});
+      auto status = oneapi::mkl::sparse::set_csr_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spmat, nrows, ncols, nnz, convert(index), row_ptr, col_ind, reinterpret_cast<std::complex<float>*>(values), {});
       device_queue->val.wait_and_throw();
    } catch (const sycl::exception& e) { return -1; }
    return 0;
 }
 
-extern "C" int onemklCsparse_set_csr_data_64(syclQueue_t device_queue, matrix_handle_t spMat, int64_t nrows, int64_t ncols, onemklIndex index, int64_t *row_ptr, int64_t *col_ind, float _Complex *values) {
+extern "C" int onemklCsparse_set_csr_data_64(syclQueue_t device_queue, matrix_handle_t spmat, int64_t nrows, int64_t ncols, int64_t nnz, onemklIndex index, int64_t *row_ptr, int64_t *col_ind, float _Complex *values) {
    try {
-      auto status = oneapi::mkl::sparse::set_csr_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spMat, nrows, ncols, convert(index), row_ptr, col_ind, reinterpret_cast<std::complex<float>*>(values), {});
+      auto status = oneapi::mkl::sparse::set_csr_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spmat, nrows, ncols, nnz, convert(index), row_ptr, col_ind, reinterpret_cast<std::complex<float>*>(values), {});
       device_queue->val.wait_and_throw();
    } catch (const sycl::exception& e) { return -1; }
    return 0;
 }
 
-extern "C" int onemklZsparse_set_csr_data(syclQueue_t device_queue, matrix_handle_t spMat, int32_t nrows, int32_t ncols, onemklIndex index, int32_t *row_ptr, int32_t *col_ind, double _Complex *values) {
+extern "C" int onemklZsparse_set_csr_data(syclQueue_t device_queue, matrix_handle_t spmat, int64_t nrows, int64_t ncols, int64_t nnz, onemklIndex index, int32_t *row_ptr, int32_t *col_ind, double _Complex *values) {
    try {
-      auto status = oneapi::mkl::sparse::set_csr_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spMat, nrows, ncols, convert(index), row_ptr, col_ind, reinterpret_cast<std::complex<double>*>(values), {});
+      auto status = oneapi::mkl::sparse::set_csr_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spmat, nrows, ncols, nnz, convert(index), row_ptr, col_ind, reinterpret_cast<std::complex<double>*>(values), {});
       device_queue->val.wait_and_throw();
    } catch (const sycl::exception& e) { return -1; }
    return 0;
 }
 
-extern "C" int onemklZsparse_set_csr_data_64(syclQueue_t device_queue, matrix_handle_t spMat, int64_t nrows, int64_t ncols, onemklIndex index, int64_t *row_ptr, int64_t *col_ind, double _Complex *values) {
+extern "C" int onemklZsparse_set_csr_data_64(syclQueue_t device_queue, matrix_handle_t spmat, int64_t nrows, int64_t ncols, int64_t nnz, onemklIndex index, int64_t *row_ptr, int64_t *col_ind, double _Complex *values) {
    try {
-      auto status = oneapi::mkl::sparse::set_csr_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spMat, nrows, ncols, convert(index), row_ptr, col_ind, reinterpret_cast<std::complex<double>*>(values), {});
+      auto status = oneapi::mkl::sparse::set_csr_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spmat, nrows, ncols, nnz, convert(index), row_ptr, col_ind, reinterpret_cast<std::complex<double>*>(values), {});
       device_queue->val.wait_and_throw();
    } catch (const sycl::exception& e) { return -1; }
    return 0;
 }
 
-extern "C" int onemklSsparse_set_coo_data(syclQueue_t device_queue, matrix_handle_t spMat, int32_t nrows, int32_t ncols, int32_t nnz, onemklIndex index, int32_t *row_ind, int32_t *col_ind, float *values) {
+extern "C" int onemklSsparse_set_csc_data(syclQueue_t device_queue, matrix_handle_t spmat, int64_t nrows, int64_t ncols, int64_t nnz, onemklIndex index, int32_t *col_ptr, int32_t *row_ind, float *values) {
    try {
-      auto status = oneapi::mkl::sparse::set_coo_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spMat, nrows, ncols, nnz, convert(index), row_ind, col_ind, values, {});
+      auto status = oneapi::mkl::sparse::set_csc_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spmat, nrows, ncols, nnz, convert(index), col_ptr, row_ind, values, {});
       device_queue->val.wait_and_throw();
    } catch (const sycl::exception& e) { return -1; }
    return 0;
 }
 
-extern "C" int onemklSsparse_set_coo_data_64(syclQueue_t device_queue, matrix_handle_t spMat, int64_t nrows, int64_t ncols, int64_t nnz, onemklIndex index, int64_t *row_ind, int64_t *col_ind, float *values) {
+extern "C" int onemklSsparse_set_csc_data_64(syclQueue_t device_queue, matrix_handle_t spmat, int64_t nrows, int64_t ncols, int64_t nnz, onemklIndex index, int64_t *col_ptr, int64_t *row_ind, float *values) {
    try {
-      auto status = oneapi::mkl::sparse::set_coo_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spMat, nrows, ncols, nnz, convert(index), row_ind, col_ind, values, {});
+      auto status = oneapi::mkl::sparse::set_csc_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spmat, nrows, ncols, nnz, convert(index), col_ptr, row_ind, values, {});
       device_queue->val.wait_and_throw();
    } catch (const sycl::exception& e) { return -1; }
    return 0;
 }
 
-extern "C" int onemklDsparse_set_coo_data(syclQueue_t device_queue, matrix_handle_t spMat, int32_t nrows, int32_t ncols, int32_t nnz, onemklIndex index, int32_t *row_ind, int32_t *col_ind, double *values) {
+extern "C" int onemklDsparse_set_csc_data(syclQueue_t device_queue, matrix_handle_t spmat, int64_t nrows, int64_t ncols, int64_t nnz, onemklIndex index, int32_t *col_ptr, int32_t *row_ind, double *values) {
    try {
-      auto status = oneapi::mkl::sparse::set_coo_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spMat, nrows, ncols, nnz, convert(index), row_ind, col_ind, values, {});
+      auto status = oneapi::mkl::sparse::set_csc_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spmat, nrows, ncols, nnz, convert(index), col_ptr, row_ind, values, {});
       device_queue->val.wait_and_throw();
    } catch (const sycl::exception& e) { return -1; }
    return 0;
 }
 
-extern "C" int onemklDsparse_set_coo_data_64(syclQueue_t device_queue, matrix_handle_t spMat, int64_t nrows, int64_t ncols, int64_t nnz, onemklIndex index, int64_t *row_ind, int64_t *col_ind, double *values) {
+extern "C" int onemklDsparse_set_csc_data_64(syclQueue_t device_queue, matrix_handle_t spmat, int64_t nrows, int64_t ncols, int64_t nnz, onemklIndex index, int64_t *col_ptr, int64_t *row_ind, double *values) {
    try {
-      auto status = oneapi::mkl::sparse::set_coo_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spMat, nrows, ncols, nnz, convert(index), row_ind, col_ind, values, {});
+      auto status = oneapi::mkl::sparse::set_csc_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spmat, nrows, ncols, nnz, convert(index), col_ptr, row_ind, values, {});
       device_queue->val.wait_and_throw();
    } catch (const sycl::exception& e) { return -1; }
    return 0;
 }
 
-extern "C" int onemklCsparse_set_coo_data(syclQueue_t device_queue, matrix_handle_t spMat, int32_t nrows, int32_t ncols, int32_t nnz, onemklIndex index, int32_t *row_ind, int32_t *col_ind, float _Complex *values) {
+extern "C" int onemklCsparse_set_csc_data(syclQueue_t device_queue, matrix_handle_t spmat, int64_t nrows, int64_t ncols, int64_t nnz, onemklIndex index, int32_t *col_ptr, int32_t *row_ind, float _Complex *values) {
    try {
-      auto status = oneapi::mkl::sparse::set_coo_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spMat, nrows, ncols, nnz, convert(index), row_ind, col_ind, reinterpret_cast<std::complex<float>*>(values), {});
+      auto status = oneapi::mkl::sparse::set_csc_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spmat, nrows, ncols, nnz, convert(index), col_ptr, row_ind, reinterpret_cast<std::complex<float>*>(values), {});
       device_queue->val.wait_and_throw();
    } catch (const sycl::exception& e) { return -1; }
    return 0;
 }
 
-extern "C" int onemklCsparse_set_coo_data_64(syclQueue_t device_queue, matrix_handle_t spMat, int64_t nrows, int64_t ncols, int64_t nnz, onemklIndex index, int64_t *row_ind, int64_t *col_ind, float _Complex *values) {
+extern "C" int onemklCsparse_set_csc_data_64(syclQueue_t device_queue, matrix_handle_t spmat, int64_t nrows, int64_t ncols, int64_t nnz, onemklIndex index, int64_t *col_ptr, int64_t *row_ind, float _Complex *values) {
    try {
-      auto status = oneapi::mkl::sparse::set_coo_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spMat, nrows, ncols, nnz, convert(index), row_ind, col_ind, reinterpret_cast<std::complex<float>*>(values), {});
+      auto status = oneapi::mkl::sparse::set_csc_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spmat, nrows, ncols, nnz, convert(index), col_ptr, row_ind, reinterpret_cast<std::complex<float>*>(values), {});
       device_queue->val.wait_and_throw();
    } catch (const sycl::exception& e) { return -1; }
    return 0;
 }
 
-extern "C" int onemklZsparse_set_coo_data(syclQueue_t device_queue, matrix_handle_t spMat, int32_t nrows, int32_t ncols, int32_t nnz, onemklIndex index, int32_t *row_ind, int32_t *col_ind, double _Complex *values) {
+extern "C" int onemklZsparse_set_csc_data(syclQueue_t device_queue, matrix_handle_t spmat, int64_t nrows, int64_t ncols, int64_t nnz, onemklIndex index, int32_t *col_ptr, int32_t *row_ind, double _Complex *values) {
    try {
-      auto status = oneapi::mkl::sparse::set_coo_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spMat, nrows, ncols, nnz, convert(index), row_ind, col_ind, reinterpret_cast<std::complex<double>*>(values), {});
+      auto status = oneapi::mkl::sparse::set_csc_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spmat, nrows, ncols, nnz, convert(index), col_ptr, row_ind, reinterpret_cast<std::complex<double>*>(values), {});
       device_queue->val.wait_and_throw();
    } catch (const sycl::exception& e) { return -1; }
    return 0;
 }
 
-extern "C" int onemklZsparse_set_coo_data_64(syclQueue_t device_queue, matrix_handle_t spMat, int64_t nrows, int64_t ncols, int64_t nnz, onemklIndex index, int64_t *row_ind, int64_t *col_ind, double _Complex *values) {
+extern "C" int onemklZsparse_set_csc_data_64(syclQueue_t device_queue, matrix_handle_t spmat, int64_t nrows, int64_t ncols, int64_t nnz, onemklIndex index, int64_t *col_ptr, int64_t *row_ind, double _Complex *values) {
    try {
-      auto status = oneapi::mkl::sparse::set_coo_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spMat, nrows, ncols, nnz, convert(index), row_ind, col_ind, reinterpret_cast<std::complex<double>*>(values), {});
+      auto status = oneapi::mkl::sparse::set_csc_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spmat, nrows, ncols, nnz, convert(index), col_ptr, row_ind, reinterpret_cast<std::complex<double>*>(values), {});
+      device_queue->val.wait_and_throw();
+   } catch (const sycl::exception& e) { return -1; }
+   return 0;
+}
+
+extern "C" int onemklSsparse_set_coo_data(syclQueue_t device_queue, matrix_handle_t spmat, int32_t nrows, int32_t ncols, int32_t nnz, onemklIndex index, int32_t *row_ind, int32_t *col_ind, float *values) {
+   try {
+      auto status = oneapi::mkl::sparse::set_coo_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spmat, nrows, ncols, nnz, convert(index), row_ind, col_ind, values, {});
+      device_queue->val.wait_and_throw();
+   } catch (const sycl::exception& e) { return -1; }
+   return 0;
+}
+
+extern "C" int onemklSsparse_set_coo_data_64(syclQueue_t device_queue, matrix_handle_t spmat, int64_t nrows, int64_t ncols, int64_t nnz, onemklIndex index, int64_t *row_ind, int64_t *col_ind, float *values) {
+   try {
+      auto status = oneapi::mkl::sparse::set_coo_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spmat, nrows, ncols, nnz, convert(index), row_ind, col_ind, values, {});
+      device_queue->val.wait_and_throw();
+   } catch (const sycl::exception& e) { return -1; }
+   return 0;
+}
+
+extern "C" int onemklDsparse_set_coo_data(syclQueue_t device_queue, matrix_handle_t spmat, int32_t nrows, int32_t ncols, int32_t nnz, onemklIndex index, int32_t *row_ind, int32_t *col_ind, double *values) {
+   try {
+      auto status = oneapi::mkl::sparse::set_coo_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spmat, nrows, ncols, nnz, convert(index), row_ind, col_ind, values, {});
+      device_queue->val.wait_and_throw();
+   } catch (const sycl::exception& e) { return -1; }
+   return 0;
+}
+
+extern "C" int onemklDsparse_set_coo_data_64(syclQueue_t device_queue, matrix_handle_t spmat, int64_t nrows, int64_t ncols, int64_t nnz, onemklIndex index, int64_t *row_ind, int64_t *col_ind, double *values) {
+   try {
+      auto status = oneapi::mkl::sparse::set_coo_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spmat, nrows, ncols, nnz, convert(index), row_ind, col_ind, values, {});
+      device_queue->val.wait_and_throw();
+   } catch (const sycl::exception& e) { return -1; }
+   return 0;
+}
+
+extern "C" int onemklCsparse_set_coo_data(syclQueue_t device_queue, matrix_handle_t spmat, int32_t nrows, int32_t ncols, int32_t nnz, onemklIndex index, int32_t *row_ind, int32_t *col_ind, float _Complex *values) {
+   try {
+      auto status = oneapi::mkl::sparse::set_coo_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spmat, nrows, ncols, nnz, convert(index), row_ind, col_ind, reinterpret_cast<std::complex<float>*>(values), {});
+      device_queue->val.wait_and_throw();
+   } catch (const sycl::exception& e) { return -1; }
+   return 0;
+}
+
+extern "C" int onemklCsparse_set_coo_data_64(syclQueue_t device_queue, matrix_handle_t spmat, int64_t nrows, int64_t ncols, int64_t nnz, onemklIndex index, int64_t *row_ind, int64_t *col_ind, float _Complex *values) {
+   try {
+      auto status = oneapi::mkl::sparse::set_coo_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spmat, nrows, ncols, nnz, convert(index), row_ind, col_ind, reinterpret_cast<std::complex<float>*>(values), {});
+      device_queue->val.wait_and_throw();
+   } catch (const sycl::exception& e) { return -1; }
+   return 0;
+}
+
+extern "C" int onemklZsparse_set_coo_data(syclQueue_t device_queue, matrix_handle_t spmat, int32_t nrows, int32_t ncols, int32_t nnz, onemklIndex index, int32_t *row_ind, int32_t *col_ind, double _Complex *values) {
+   try {
+      auto status = oneapi::mkl::sparse::set_coo_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spmat, nrows, ncols, nnz, convert(index), row_ind, col_ind, reinterpret_cast<std::complex<double>*>(values), {});
+      device_queue->val.wait_and_throw();
+   } catch (const sycl::exception& e) { return -1; }
+   return 0;
+}
+
+extern "C" int onemklZsparse_set_coo_data_64(syclQueue_t device_queue, matrix_handle_t spmat, int64_t nrows, int64_t ncols, int64_t nnz, onemklIndex index, int64_t *row_ind, int64_t *col_ind, double _Complex *values) {
+   try {
+      auto status = oneapi::mkl::sparse::set_coo_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spmat, nrows, ncols, nnz, convert(index), row_ind, col_ind, reinterpret_cast<std::complex<double>*>(values), {});
+      device_queue->val.wait_and_throw();
+   } catch (const sycl::exception& e) { return -1; }
+   return 0;
+}
+
+extern "C" int onemklSsparse_set_bsr_data(syclQueue_t device_queue, matrix_handle_t spmat, int64_t blk_nrows, int64_t blk_ncols, int64_t blk_nnz, int64_t row_blk_size, int64_t col_blk_size, onemklLayout blk_layout, onemklIndex index, int32_t *bsr_row_ptr, int32_t *bsr_col_ind, float *bsr_values) {
+   try {
+      auto status = oneapi::mkl::sparse::set_bsr_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spmat, blk_nrows, blk_ncols, blk_nnz, row_blk_size, col_blk_size, convert(blk_layout), convert(index), bsr_row_ptr, bsr_col_ind, bsr_values, {});
+      device_queue->val.wait_and_throw();
+   } catch (const sycl::exception& e) { return -1; }
+   return 0;
+}
+
+extern "C" int onemklSsparse_set_bsr_data_64(syclQueue_t device_queue, matrix_handle_t spmat, int64_t blk_nrows, int64_t blk_ncols, int64_t blk_nnz, int64_t row_blk_size, int64_t col_blk_size, onemklLayout blk_layout, onemklIndex index, int64_t *bsr_row_ptr, int64_t *bsr_col_ind, float *bsr_values) {
+   try {
+      auto status = oneapi::mkl::sparse::set_bsr_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spmat, blk_nrows, blk_ncols, blk_nnz, row_blk_size, col_blk_size, convert(blk_layout), convert(index), bsr_row_ptr, bsr_col_ind, bsr_values, {});
+      device_queue->val.wait_and_throw();
+   } catch (const sycl::exception& e) { return -1; }
+   return 0;
+}
+
+extern "C" int onemklDsparse_set_bsr_data(syclQueue_t device_queue, matrix_handle_t spmat, int64_t blk_nrows, int64_t blk_ncols, int64_t blk_nnz, int64_t row_blk_size, int64_t col_blk_size, onemklLayout blk_layout, onemklIndex index, int32_t *bsr_row_ptr, int32_t *bsr_col_ind, double *bsr_values) {
+   try {
+      auto status = oneapi::mkl::sparse::set_bsr_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spmat, blk_nrows, blk_ncols, blk_nnz, row_blk_size, col_blk_size, convert(blk_layout), convert(index), bsr_row_ptr, bsr_col_ind, bsr_values, {});
+      device_queue->val.wait_and_throw();
+   } catch (const sycl::exception& e) { return -1; }
+   return 0;
+}
+
+extern "C" int onemklDsparse_set_bsr_data_64(syclQueue_t device_queue, matrix_handle_t spmat, int64_t blk_nrows, int64_t blk_ncols, int64_t blk_nnz, int64_t row_blk_size, int64_t col_blk_size, onemklLayout blk_layout, onemklIndex index, int64_t *bsr_row_ptr, int64_t *bsr_col_ind, double *bsr_values) {
+   try {
+      auto status = oneapi::mkl::sparse::set_bsr_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spmat, blk_nrows, blk_ncols, blk_nnz, row_blk_size, col_blk_size, convert(blk_layout), convert(index), bsr_row_ptr, bsr_col_ind, bsr_values, {});
+      device_queue->val.wait_and_throw();
+   } catch (const sycl::exception& e) { return -1; }
+   return 0;
+}
+
+extern "C" int onemklCsparse_set_bsr_data(syclQueue_t device_queue, matrix_handle_t spmat, int64_t blk_nrows, int64_t blk_ncols, int64_t blk_nnz, int64_t row_blk_size, int64_t col_blk_size, onemklLayout blk_layout, onemklIndex index, int32_t *bsr_row_ptr, int32_t *bsr_col_ind, float _Complex *bsr_values) {
+   try {
+      auto status = oneapi::mkl::sparse::set_bsr_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spmat, blk_nrows, blk_ncols, blk_nnz, row_blk_size, col_blk_size, convert(blk_layout), convert(index), bsr_row_ptr, bsr_col_ind, reinterpret_cast<std::complex<float>*>(bsr_values), {});
+      device_queue->val.wait_and_throw();
+   } catch (const sycl::exception& e) { return -1; }
+   return 0;
+}
+
+extern "C" int onemklCsparse_set_bsr_data_64(syclQueue_t device_queue, matrix_handle_t spmat, int64_t blk_nrows, int64_t blk_ncols, int64_t blk_nnz, int64_t row_blk_size, int64_t col_blk_size, onemklLayout blk_layout, onemklIndex index, int64_t *bsr_row_ptr, int64_t *bsr_col_ind, float _Complex *bsr_values) {
+   try {
+      auto status = oneapi::mkl::sparse::set_bsr_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spmat, blk_nrows, blk_ncols, blk_nnz, row_blk_size, col_blk_size, convert(blk_layout), convert(index), bsr_row_ptr, bsr_col_ind, reinterpret_cast<std::complex<float>*>(bsr_values), {});
+      device_queue->val.wait_and_throw();
+   } catch (const sycl::exception& e) { return -1; }
+   return 0;
+}
+
+extern "C" int onemklZsparse_set_bsr_data(syclQueue_t device_queue, matrix_handle_t spmat, int64_t blk_nrows, int64_t blk_ncols, int64_t blk_nnz, int64_t row_blk_size, int64_t col_blk_size, onemklLayout blk_layout, onemklIndex index, int32_t *bsr_row_ptr, int32_t *bsr_col_ind, double _Complex *bsr_values) {
+   try {
+      auto status = oneapi::mkl::sparse::set_bsr_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spmat, blk_nrows, blk_ncols, blk_nnz, row_blk_size, col_blk_size, convert(blk_layout), convert(index), bsr_row_ptr, bsr_col_ind, reinterpret_cast<std::complex<double>*>(bsr_values), {});
+      device_queue->val.wait_and_throw();
+   } catch (const sycl::exception& e) { return -1; }
+   return 0;
+}
+
+extern "C" int onemklZsparse_set_bsr_data_64(syclQueue_t device_queue, matrix_handle_t spmat, int64_t blk_nrows, int64_t blk_ncols, int64_t blk_nnz, int64_t row_blk_size, int64_t col_blk_size, onemklLayout blk_layout, onemklIndex index, int64_t *bsr_row_ptr, int64_t *bsr_col_ind, double _Complex *bsr_values) {
+   try {
+      auto status = oneapi::mkl::sparse::set_bsr_data(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spmat, blk_nrows, blk_ncols, blk_nnz, row_blk_size, col_blk_size, convert(blk_layout), convert(index), bsr_row_ptr, bsr_col_ind, reinterpret_cast<std::complex<double>*>(bsr_values), {});
       device_queue->val.wait_and_throw();
    } catch (const sycl::exception& e) { return -1; }
    return 0;
@@ -5654,49 +5785,49 @@ extern "C" int onemklXsparse_release_omatadd_descr(syclQueue_t device_queue, oma
    return 0;
 }
 
-extern "C" int onemklXsparse_omatcopy(syclQueue_t device_queue, onemklTranspose transpose_val, matrix_handle_t spMat_in, matrix_handle_t spMat_out) {
+extern "C" int onemklXsparse_omatcopy(syclQueue_t device_queue, onemklTranspose transpose_val, matrix_handle_t spmat_in, matrix_handle_t spmat_out) {
    try {
-      auto status = oneapi::mkl::sparse::omatcopy(device_queue->val, convert(transpose_val), (oneapi::mkl::sparse::matrix_handle_t) spMat_in, (oneapi::mkl::sparse::matrix_handle_t) spMat_out, {});
+      auto status = oneapi::mkl::sparse::omatcopy(device_queue->val, convert(transpose_val), (oneapi::mkl::sparse::matrix_handle_t) spmat_in, (oneapi::mkl::sparse::matrix_handle_t) spmat_out, {});
       device_queue->val.wait_and_throw();
    } catch (const sycl::exception& e) { return -1; }
    return 0;
 }
 
-extern "C" int onemklXsparse_sort_matrix(syclQueue_t device_queue, matrix_handle_t spMat) {
+extern "C" int onemklXsparse_sort_matrix(syclQueue_t device_queue, matrix_handle_t spmat) {
    try {
-      auto status = oneapi::mkl::sparse::sort_matrix(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spMat, {});
+      auto status = oneapi::mkl::sparse::sort_matrix(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spmat, {});
       device_queue->val.wait_and_throw();
    } catch (const sycl::exception& e) { return -1; }
    return 0;
 }
 
-extern "C" int onemklSsparse_update_diagonal_values(syclQueue_t device_queue, matrix_handle_t spMat, int64_t length, float *new_diag_values) {
+extern "C" int onemklSsparse_update_diagonal_values(syclQueue_t device_queue, matrix_handle_t spmat, int64_t length, float *new_diag_values) {
    try {
-      auto status = oneapi::mkl::sparse::update_diagonal_values(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spMat, length, new_diag_values, {});
+      auto status = oneapi::mkl::sparse::update_diagonal_values(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spmat, length, new_diag_values, {});
       device_queue->val.wait_and_throw();
    } catch (const sycl::exception& e) { return -1; }
    return 0;
 }
 
-extern "C" int onemklDsparse_update_diagonal_values(syclQueue_t device_queue, matrix_handle_t spMat, int64_t length, double *new_diag_values) {
+extern "C" int onemklDsparse_update_diagonal_values(syclQueue_t device_queue, matrix_handle_t spmat, int64_t length, double *new_diag_values) {
    try {
-      auto status = oneapi::mkl::sparse::update_diagonal_values(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spMat, length, new_diag_values, {});
+      auto status = oneapi::mkl::sparse::update_diagonal_values(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spmat, length, new_diag_values, {});
       device_queue->val.wait_and_throw();
    } catch (const sycl::exception& e) { return -1; }
    return 0;
 }
 
-extern "C" int onemklCsparse_update_diagonal_values(syclQueue_t device_queue, matrix_handle_t spMat, int64_t length, float _Complex *new_diag_values) {
+extern "C" int onemklCsparse_update_diagonal_values(syclQueue_t device_queue, matrix_handle_t spmat, int64_t length, float _Complex *new_diag_values) {
    try {
-      auto status = oneapi::mkl::sparse::update_diagonal_values(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spMat, length, reinterpret_cast<std::complex<float>*>(new_diag_values), {});
+      auto status = oneapi::mkl::sparse::update_diagonal_values(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spmat, length, reinterpret_cast<std::complex<float>*>(new_diag_values), {});
       device_queue->val.wait_and_throw();
    } catch (const sycl::exception& e) { return -1; }
    return 0;
 }
 
-extern "C" int onemklZsparse_update_diagonal_values(syclQueue_t device_queue, matrix_handle_t spMat, int64_t length, double _Complex *new_diag_values) {
+extern "C" int onemklZsparse_update_diagonal_values(syclQueue_t device_queue, matrix_handle_t spmat, int64_t length, double _Complex *new_diag_values) {
    try {
-      auto status = oneapi::mkl::sparse::update_diagonal_values(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spMat, length, reinterpret_cast<std::complex<double>*>(new_diag_values), {});
+      auto status = oneapi::mkl::sparse::update_diagonal_values(device_queue->val, (oneapi::mkl::sparse::matrix_handle_t) spmat, length, reinterpret_cast<std::complex<double>*>(new_diag_values), {});
       device_queue->val.wait_and_throw();
    } catch (const sycl::exception& e) { return -1; }
    return 0;

--- a/deps/src/onemkl.h
+++ b/deps/src/onemkl.h
@@ -140,9 +140,6 @@ typedef struct omatconvert_descr *omatconvert_descr_t;
 struct omatadd_descr;
 typedef struct omatadd_descr *omatadd_descr_t;
 
-const int64_t ONEMKL_VERSION_MAJOR = 2026;
-const int64_t ONEMKL_VERSION_MINOR = 0;
-const int64_t ONEMKL_VERSION_PATCH = 0;
 void onemkl_version(int64_t *major, int64_t *minor, int64_t *patch);
 
 int onemklHgemm_batch(syclQueue_t device_queue, onemklTranspose transa,
@@ -2737,73 +2734,153 @@ int64_t onemklZunmqr_batch_scratchpad_size(syclQueue_t device_queue, onemklSide*
                                            group_count, int64_t* group_sizes);
 
 // SPARSE
-int onemklXsparse_init_matrix_handle(matrix_handle_t *p_spMat);
+int onemklXsparse_init_matrix_handle(matrix_handle_t *p_spmat);
 
-int onemklXsparse_release_matrix_handle(syclQueue_t device_queue, matrix_handle_t *p_spMat);
+int onemklXsparse_release_matrix_handle(syclQueue_t device_queue, matrix_handle_t *p_spmat);
 
-int onemklSsparse_set_csr_data(syclQueue_t device_queue, matrix_handle_t spMat, int32_t nrows,
-                               int32_t ncols, onemklIndex index, int32_t *row_ptr, int32_t
-                               *col_ind, float *values);
+int onemklSsparse_set_csr_data(syclQueue_t device_queue, matrix_handle_t spmat, int64_t nrows,
+                               int64_t ncols, int64_t nnz, onemklIndex index, int32_t *row_ptr,
+                               int32_t *col_ind, float *values);
 
-int onemklSsparse_set_csr_data_64(syclQueue_t device_queue, matrix_handle_t spMat, int64_t
-                                  nrows, int64_t ncols, onemklIndex index, int64_t *row_ptr,
-                                  int64_t *col_ind, float *values);
+int onemklSsparse_set_csr_data_64(syclQueue_t device_queue, matrix_handle_t spmat, int64_t
+                                  nrows, int64_t ncols, int64_t nnz, onemklIndex index, int64_t
+                                  *row_ptr, int64_t *col_ind, float *values);
 
-int onemklDsparse_set_csr_data(syclQueue_t device_queue, matrix_handle_t spMat, int32_t nrows,
-                               int32_t ncols, onemklIndex index, int32_t *row_ptr, int32_t
-                               *col_ind, double *values);
+int onemklDsparse_set_csr_data(syclQueue_t device_queue, matrix_handle_t spmat, int64_t nrows,
+                               int64_t ncols, int64_t nnz, onemklIndex index, int32_t *row_ptr,
+                               int32_t *col_ind, double *values);
 
-int onemklDsparse_set_csr_data_64(syclQueue_t device_queue, matrix_handle_t spMat, int64_t
-                                  nrows, int64_t ncols, onemklIndex index, int64_t *row_ptr,
-                                  int64_t *col_ind, double *values);
+int onemklDsparse_set_csr_data_64(syclQueue_t device_queue, matrix_handle_t spmat, int64_t
+                                  nrows, int64_t ncols, int64_t nnz, onemklIndex index, int64_t
+                                  *row_ptr, int64_t *col_ind, double *values);
 
-int onemklCsparse_set_csr_data(syclQueue_t device_queue, matrix_handle_t spMat, int32_t nrows,
-                               int32_t ncols, onemklIndex index, int32_t *row_ptr, int32_t
-                               *col_ind, float _Complex *values);
+int onemklCsparse_set_csr_data(syclQueue_t device_queue, matrix_handle_t spmat, int64_t nrows,
+                               int64_t ncols, int64_t nnz, onemklIndex index, int32_t *row_ptr,
+                               int32_t *col_ind, float _Complex *values);
 
-int onemklCsparse_set_csr_data_64(syclQueue_t device_queue, matrix_handle_t spMat, int64_t
-                                  nrows, int64_t ncols, onemklIndex index, int64_t *row_ptr,
-                                  int64_t *col_ind, float _Complex *values);
+int onemklCsparse_set_csr_data_64(syclQueue_t device_queue, matrix_handle_t spmat, int64_t
+                                  nrows, int64_t ncols, int64_t nnz, onemklIndex index, int64_t
+                                  *row_ptr, int64_t *col_ind, float _Complex *values);
 
-int onemklZsparse_set_csr_data(syclQueue_t device_queue, matrix_handle_t spMat, int32_t nrows,
-                               int32_t ncols, onemklIndex index, int32_t *row_ptr, int32_t
-                               *col_ind, double _Complex *values);
+int onemklZsparse_set_csr_data(syclQueue_t device_queue, matrix_handle_t spmat, int64_t nrows,
+                               int64_t ncols, int64_t nnz, onemklIndex index, int32_t *row_ptr,
+                               int32_t *col_ind, double _Complex *values);
 
-int onemklZsparse_set_csr_data_64(syclQueue_t device_queue, matrix_handle_t spMat, int64_t
-                                  nrows, int64_t ncols, onemklIndex index, int64_t *row_ptr,
-                                  int64_t *col_ind, double _Complex *values);
+int onemklZsparse_set_csr_data_64(syclQueue_t device_queue, matrix_handle_t spmat, int64_t
+                                  nrows, int64_t ncols, int64_t nnz, onemklIndex index, int64_t
+                                  *row_ptr, int64_t *col_ind, double _Complex *values);
 
-int onemklSsparse_set_coo_data(syclQueue_t device_queue, matrix_handle_t spMat, int32_t nrows,
+int onemklSsparse_set_csc_data(syclQueue_t device_queue, matrix_handle_t spmat, int64_t nrows,
+                               int64_t ncols, int64_t nnz, onemklIndex index, int32_t *col_ptr,
+                               int32_t *row_ind, float *values);
+
+int onemklSsparse_set_csc_data_64(syclQueue_t device_queue, matrix_handle_t spmat, int64_t
+                                  nrows, int64_t ncols, int64_t nnz, onemklIndex index, int64_t
+                                  *col_ptr, int64_t *row_ind, float *values);
+
+int onemklDsparse_set_csc_data(syclQueue_t device_queue, matrix_handle_t spmat, int64_t nrows,
+                               int64_t ncols, int64_t nnz, onemklIndex index, int32_t *col_ptr,
+                               int32_t *row_ind, double *values);
+
+int onemklDsparse_set_csc_data_64(syclQueue_t device_queue, matrix_handle_t spmat, int64_t
+                                  nrows, int64_t ncols, int64_t nnz, onemklIndex index, int64_t
+                                  *col_ptr, int64_t *row_ind, double *values);
+
+int onemklCsparse_set_csc_data(syclQueue_t device_queue, matrix_handle_t spmat, int64_t nrows,
+                               int64_t ncols, int64_t nnz, onemklIndex index, int32_t *col_ptr,
+                               int32_t *row_ind, float _Complex *values);
+
+int onemklCsparse_set_csc_data_64(syclQueue_t device_queue, matrix_handle_t spmat, int64_t
+                                  nrows, int64_t ncols, int64_t nnz, onemklIndex index, int64_t
+                                  *col_ptr, int64_t *row_ind, float _Complex *values);
+
+int onemklZsparse_set_csc_data(syclQueue_t device_queue, matrix_handle_t spmat, int64_t nrows,
+                               int64_t ncols, int64_t nnz, onemklIndex index, int32_t *col_ptr,
+                               int32_t *row_ind, double _Complex *values);
+
+int onemklZsparse_set_csc_data_64(syclQueue_t device_queue, matrix_handle_t spmat, int64_t
+                                  nrows, int64_t ncols, int64_t nnz, onemklIndex index, int64_t
+                                  *col_ptr, int64_t *row_ind, double _Complex *values);
+
+int onemklSsparse_set_coo_data(syclQueue_t device_queue, matrix_handle_t spmat, int32_t nrows,
                                int32_t ncols, int32_t nnz, onemklIndex index, int32_t *row_ind,
                                int32_t *col_ind, float *values);
 
-int onemklSsparse_set_coo_data_64(syclQueue_t device_queue, matrix_handle_t spMat, int64_t
+int onemklSsparse_set_coo_data_64(syclQueue_t device_queue, matrix_handle_t spmat, int64_t
                                   nrows, int64_t ncols, int64_t nnz, onemklIndex index, int64_t
                                   *row_ind, int64_t *col_ind, float *values);
 
-int onemklDsparse_set_coo_data(syclQueue_t device_queue, matrix_handle_t spMat, int32_t nrows,
+int onemklDsparse_set_coo_data(syclQueue_t device_queue, matrix_handle_t spmat, int32_t nrows,
                                int32_t ncols, int32_t nnz, onemklIndex index, int32_t *row_ind,
                                int32_t *col_ind, double *values);
 
-int onemklDsparse_set_coo_data_64(syclQueue_t device_queue, matrix_handle_t spMat, int64_t
+int onemklDsparse_set_coo_data_64(syclQueue_t device_queue, matrix_handle_t spmat, int64_t
                                   nrows, int64_t ncols, int64_t nnz, onemklIndex index, int64_t
                                   *row_ind, int64_t *col_ind, double *values);
 
-int onemklCsparse_set_coo_data(syclQueue_t device_queue, matrix_handle_t spMat, int32_t nrows,
+int onemklCsparse_set_coo_data(syclQueue_t device_queue, matrix_handle_t spmat, int32_t nrows,
                                int32_t ncols, int32_t nnz, onemklIndex index, int32_t *row_ind,
                                int32_t *col_ind, float _Complex *values);
 
-int onemklCsparse_set_coo_data_64(syclQueue_t device_queue, matrix_handle_t spMat, int64_t
+int onemklCsparse_set_coo_data_64(syclQueue_t device_queue, matrix_handle_t spmat, int64_t
                                   nrows, int64_t ncols, int64_t nnz, onemklIndex index, int64_t
                                   *row_ind, int64_t *col_ind, float _Complex *values);
 
-int onemklZsparse_set_coo_data(syclQueue_t device_queue, matrix_handle_t spMat, int32_t nrows,
+int onemklZsparse_set_coo_data(syclQueue_t device_queue, matrix_handle_t spmat, int32_t nrows,
                                int32_t ncols, int32_t nnz, onemklIndex index, int32_t *row_ind,
                                int32_t *col_ind, double _Complex *values);
 
-int onemklZsparse_set_coo_data_64(syclQueue_t device_queue, matrix_handle_t spMat, int64_t
+int onemklZsparse_set_coo_data_64(syclQueue_t device_queue, matrix_handle_t spmat, int64_t
                                   nrows, int64_t ncols, int64_t nnz, onemklIndex index, int64_t
                                   *row_ind, int64_t *col_ind, double _Complex *values);
+
+int onemklSsparse_set_bsr_data(syclQueue_t device_queue, matrix_handle_t spmat, int64_t
+                               blk_nrows, int64_t blk_ncols, int64_t blk_nnz, int64_t
+                               row_blk_size, int64_t col_blk_size, onemklLayout blk_layout,
+                               onemklIndex index, int32_t *bsr_row_ptr, int32_t *bsr_col_ind,
+                               float *bsr_values);
+
+int onemklSsparse_set_bsr_data_64(syclQueue_t device_queue, matrix_handle_t spmat, int64_t
+                                  blk_nrows, int64_t blk_ncols, int64_t blk_nnz, int64_t
+                                  row_blk_size, int64_t col_blk_size, onemklLayout blk_layout,
+                                  onemklIndex index, int64_t *bsr_row_ptr, int64_t
+                                  *bsr_col_ind, float *bsr_values);
+
+int onemklDsparse_set_bsr_data(syclQueue_t device_queue, matrix_handle_t spmat, int64_t
+                               blk_nrows, int64_t blk_ncols, int64_t blk_nnz, int64_t
+                               row_blk_size, int64_t col_blk_size, onemklLayout blk_layout,
+                               onemklIndex index, int32_t *bsr_row_ptr, int32_t *bsr_col_ind,
+                               double *bsr_values);
+
+int onemklDsparse_set_bsr_data_64(syclQueue_t device_queue, matrix_handle_t spmat, int64_t
+                                  blk_nrows, int64_t blk_ncols, int64_t blk_nnz, int64_t
+                                  row_blk_size, int64_t col_blk_size, onemklLayout blk_layout,
+                                  onemklIndex index, int64_t *bsr_row_ptr, int64_t
+                                  *bsr_col_ind, double *bsr_values);
+
+int onemklCsparse_set_bsr_data(syclQueue_t device_queue, matrix_handle_t spmat, int64_t
+                               blk_nrows, int64_t blk_ncols, int64_t blk_nnz, int64_t
+                               row_blk_size, int64_t col_blk_size, onemklLayout blk_layout,
+                               onemklIndex index, int32_t *bsr_row_ptr, int32_t *bsr_col_ind,
+                               float _Complex *bsr_values);
+
+int onemklCsparse_set_bsr_data_64(syclQueue_t device_queue, matrix_handle_t spmat, int64_t
+                                  blk_nrows, int64_t blk_ncols, int64_t blk_nnz, int64_t
+                                  row_blk_size, int64_t col_blk_size, onemklLayout blk_layout,
+                                  onemklIndex index, int64_t *bsr_row_ptr, int64_t
+                                  *bsr_col_ind, float _Complex *bsr_values);
+
+int onemklZsparse_set_bsr_data(syclQueue_t device_queue, matrix_handle_t spmat, int64_t
+                               blk_nrows, int64_t blk_ncols, int64_t blk_nnz, int64_t
+                               row_blk_size, int64_t col_blk_size, onemklLayout blk_layout,
+                               onemklIndex index, int32_t *bsr_row_ptr, int32_t *bsr_col_ind,
+                               double _Complex *bsr_values);
+
+int onemklZsparse_set_bsr_data_64(syclQueue_t device_queue, matrix_handle_t spmat, int64_t
+                                  blk_nrows, int64_t blk_ncols, int64_t blk_nnz, int64_t
+                                  row_blk_size, int64_t col_blk_size, onemklLayout blk_layout,
+                                  onemklIndex index, int64_t *bsr_row_ptr, int64_t
+                                  *bsr_col_ind, double _Complex *bsr_values);
 
 int onemklXsparse_init_matmat_descr(matmat_descr_t *p_desc);
 
@@ -2822,20 +2899,20 @@ int onemklXsparse_release_omatadd_descr(syclQueue_t device_queue, omatadd_descr_
                                         omatadd_desc);
 
 int onemklXsparse_omatcopy(syclQueue_t device_queue, onemklTranspose transpose_val,
-                           matrix_handle_t spMat_in, matrix_handle_t spMat_out);
+                           matrix_handle_t spmat_in, matrix_handle_t spmat_out);
 
-int onemklXsparse_sort_matrix(syclQueue_t device_queue, matrix_handle_t spMat);
+int onemklXsparse_sort_matrix(syclQueue_t device_queue, matrix_handle_t spmat);
 
-int onemklSsparse_update_diagonal_values(syclQueue_t device_queue, matrix_handle_t spMat,
+int onemklSsparse_update_diagonal_values(syclQueue_t device_queue, matrix_handle_t spmat,
                                          int64_t length, float *new_diag_values);
 
-int onemklDsparse_update_diagonal_values(syclQueue_t device_queue, matrix_handle_t spMat,
+int onemklDsparse_update_diagonal_values(syclQueue_t device_queue, matrix_handle_t spmat,
                                          int64_t length, double *new_diag_values);
 
-int onemklCsparse_update_diagonal_values(syclQueue_t device_queue, matrix_handle_t spMat,
+int onemklCsparse_update_diagonal_values(syclQueue_t device_queue, matrix_handle_t spmat,
                                          int64_t length, float _Complex *new_diag_values);
 
-int onemklZsparse_update_diagonal_values(syclQueue_t device_queue, matrix_handle_t spMat,
+int onemklZsparse_update_diagonal_values(syclQueue_t device_queue, matrix_handle_t spmat,
                                          int64_t length, double _Complex *new_diag_values);
 
 int onemklXsparse_optimize_gemv(syclQueue_t device_queue, onemklTranspose opA, matrix_handle_t

--- a/lib/mkl/wrappers_sparse.jl
+++ b/lib/mkl/wrappers_sparse.jl
@@ -38,6 +38,18 @@ function flush_deferred_sparse_releases()
     return synchronize(queue)
 end
 
+# The CSC setters are exported by the support library unconditionally, but compile to
+# unsupported stubs when the library was built against an oneMKL without the wide sparse
+# API (2025.2 and older); turn that into a clear error instead of a silent no-op.
+csc_supported() = version() >= v"2025.3"
+function _check_csc_support()
+    csc_supported() && return
+    error(
+        "oneSparseMatrixCSC requires a support library built against oneMKL 2025.3 or " *
+        "later; the loaded one was built against oneMKL $(version())."
+    )
+end
+
 for (fname, elty, intty) in ((:onemklSsparse_set_csr_data   , :Float32   , :Int32),
                              (:onemklSsparse_set_csr_data_64, :Float32   , :Int64),
                              (:onemklDsparse_set_csr_data   , :Float64   , :Int32),
@@ -60,7 +72,8 @@ for (fname, elty, intty) in ((:onemklSsparse_set_csr_data   , :Float32   , :Int3
             queue = global_queue(context(nzVal), device(nzVal))
             # Don't update handle if matrix is empty
             if m != 0 && n != 0
-                $fname(sycl_queue(queue), handle_ptr[], m, n, 'O', rowPtr, colVal, nzVal)
+                Support._check_sparse_abi()
+                $fname(sycl_queue(queue), handle_ptr[], m, n, nnzA, 'O', rowPtr, colVal, nzVal)
                 dA = oneSparseMatrixCSR{$elty, $intty}(handle_ptr[], rowPtr, colVal, nzVal, (m, n), nnzA)
                 finalizer(sparse_release_matrix_handle, dA)
             else
@@ -81,7 +94,9 @@ for (fname, elty, intty) in ((:onemklSsparse_set_csr_data   , :Float32   , :Int3
             nnzA = length(nzVal)
             # Don't update handle if matrix is empty
             if m != 0 && n != 0
-                $fname(sycl_queue(queue), handle_ptr[], n, m, 'O', colPtr, rowVal, nzVal)  # CSC of A is CSR of Aᵀ
+                Support._check_sparse_abi()
+                _check_csc_support()
+                $fname(sycl_queue(queue), handle_ptr[], n, m, nnzA, 'O', colPtr, rowVal, nzVal)  # CSC of A is CSR of Aᵀ
                 dA = oneSparseMatrixCSC{$elty, $intty}(handle_ptr[], colPtr, rowVal, nzVal, (m, n), nnzA)
                 finalizer(sparse_release_matrix_handle, dA)
             else
@@ -144,6 +159,7 @@ for (fname, elty, intty) in ((:onemklSsparse_set_coo_data   , :Float32   , :Int3
             nnzA = length(val)
             queue = global_queue(context(nzVal), device(nzVal))
             if m != 0 && n != 0
+                Support._check_sparse_abi()
                 $fname(sycl_queue(queue), handle_ptr[], m, n, nnzA, 'O', rowInd, colInd, nzVal)
                 dA = oneSparseMatrixCOO{$elty, $intty}(handle_ptr[], rowInd, colInd, nzVal, (m, n), nnzA)
                 finalizer(sparse_release_matrix_handle, dA)

--- a/lib/support/Support.jl
+++ b/lib/support/Support.jl
@@ -10,6 +10,8 @@ using ..oneL0:
 
 using oneAPI_Support_jll
 
+import Libdl
+
 include("liboneapi_support.jl")
 
 # export everything
@@ -19,13 +21,41 @@ for n in names(@__MODULE__; all=true)
     end
 end
 
+# The sparse wrappers were regenerated with a wider ABI: the onemklX sparse_set_{csr,csc,coo}
+# setters gained a 64-bit `nnz` argument and 64-bit dims, and new set_csc_data / set_bsr_data
+# entry points were added. These only match a liboneapi_support built from the updated
+# onemkl.cpp/onemkl.h. The oneAPI_Support_jll 0.9.2 binary shipped in the registry predates
+# them, so calling a sparse setter against it shifts every pointer one slot and MKL
+# dereferences garbage -> segfault or silently corrupted sparse data. `deps/build_local.jl`
+# rebuilds a matching binary; a plain `Pkg.add` / CI `julia-buildpkg` does not. Probe once at
+# load for a symbol that only the rebuilt binary exports and turn the crash into a clear error.
+const _sparse_abi_ok = Ref(false)
+
+function _check_sparse_abi()
+    _sparse_abi_ok[] && return
+    error(
+        "The loaded oneAPI_Support_jll binary predates the current sparse wrappers and has an " *
+        "incompatible ABI; calling sparse routines against it would corrupt memory or crash. " *
+        "Rebuild the support library from source with `julia --project deps/build_local.jl` " *
+        "(or install a oneAPI_Support_jll built from the updated onemkl.cpp)."
+    )
+end
+
 function __init__()
     precompiling = ccall(:jl_generating_output, Cint, ()) != 0
     precompiling && return
-    
+
     if !oneAPI_Support_jll.is_available()
         @error """oneAPI support wrapper not available for your platform."""
         return
+    end
+
+    # Probe the loaded support binary for a symbol that only the regenerated (wide-ABI)
+    # sparse wrappers export; `_check_sparse_abi` gates the affected calls on the result.
+    handle = Libdl.dlopen(oneAPI_Support_jll.liboneapi_support; throw_error = false)
+    if handle !== nothing
+        _sparse_abi_ok[] =
+            Libdl.dlsym(handle, :onemklSsparse_set_csc_data; throw_error = false) !== nothing
     end
 end
 

--- a/lib/support/liboneapi_support.jl
+++ b/lib/support/liboneapi_support.jl
@@ -6428,107 +6428,195 @@ function onemklZunmqr_batch_scratchpad_size(device_queue, side, trans, m, n, k, 
                                                                 group_sizes::Ptr{Int64})::Int64
 end
 
-function onemklXsparse_init_matrix_handle(p_spMat)
-    @ccall liboneapi_support.onemklXsparse_init_matrix_handle(p_spMat::Ptr{matrix_handle_t})::Cint
+function onemklXsparse_init_matrix_handle(p_spmat)
+    @ccall liboneapi_support.onemklXsparse_init_matrix_handle(p_spmat::Ptr{matrix_handle_t})::Cint
 end
 
-function onemklXsparse_release_matrix_handle(device_queue, p_spMat)
+function onemklXsparse_release_matrix_handle(device_queue, p_spmat)
     @ccall liboneapi_support.onemklXsparse_release_matrix_handle(device_queue::syclQueue_t,
-                                                                 p_spMat::Ptr{matrix_handle_t})::Cint
+                                                                 p_spmat::Ptr{matrix_handle_t})::Cint
 end
 
-function onemklSsparse_set_csr_data(device_queue, spMat, nrows, ncols, index, row_ptr,
+function onemklSsparse_set_csr_data(device_queue, spmat, nrows, ncols, nnz, index, row_ptr,
                                     col_ind, values)
     @ccall liboneapi_support.onemklSsparse_set_csr_data(device_queue::syclQueue_t,
-                                                        spMat::matrix_handle_t,
-                                                        nrows::Int32, ncols::Int32,
-                                                        index::onemklIndex,
+                                                        spmat::matrix_handle_t,
+                                                        nrows::Int64, ncols::Int64,
+                                                        nnz::Int64, index::onemklIndex,
                                                         row_ptr::ZePtr{Int32},
                                                         col_ind::ZePtr{Int32},
                                                         values::ZePtr{Cfloat})::Cint
 end
 
-function onemklSsparse_set_csr_data_64(device_queue, spMat, nrows, ncols, index, row_ptr,
-                                       col_ind, values)
+function onemklSsparse_set_csr_data_64(device_queue, spmat, nrows, ncols, nnz, index,
+                                       row_ptr, col_ind, values)
     @ccall liboneapi_support.onemklSsparse_set_csr_data_64(device_queue::syclQueue_t,
-                                                           spMat::matrix_handle_t,
+                                                           spmat::matrix_handle_t,
                                                            nrows::Int64, ncols::Int64,
-                                                           index::onemklIndex,
+                                                           nnz::Int64, index::onemklIndex,
                                                            row_ptr::ZePtr{Int64},
                                                            col_ind::ZePtr{Int64},
                                                            values::ZePtr{Cfloat})::Cint
 end
 
-function onemklDsparse_set_csr_data(device_queue, spMat, nrows, ncols, index, row_ptr,
+function onemklDsparse_set_csr_data(device_queue, spmat, nrows, ncols, nnz, index, row_ptr,
                                     col_ind, values)
     @ccall liboneapi_support.onemklDsparse_set_csr_data(device_queue::syclQueue_t,
-                                                        spMat::matrix_handle_t,
-                                                        nrows::Int32, ncols::Int32,
-                                                        index::onemklIndex,
+                                                        spmat::matrix_handle_t,
+                                                        nrows::Int64, ncols::Int64,
+                                                        nnz::Int64, index::onemklIndex,
                                                         row_ptr::ZePtr{Int32},
                                                         col_ind::ZePtr{Int32},
                                                         values::ZePtr{Cdouble})::Cint
 end
 
-function onemklDsparse_set_csr_data_64(device_queue, spMat, nrows, ncols, index, row_ptr,
-                                       col_ind, values)
+function onemklDsparse_set_csr_data_64(device_queue, spmat, nrows, ncols, nnz, index,
+                                       row_ptr, col_ind, values)
     @ccall liboneapi_support.onemklDsparse_set_csr_data_64(device_queue::syclQueue_t,
-                                                           spMat::matrix_handle_t,
+                                                           spmat::matrix_handle_t,
                                                            nrows::Int64, ncols::Int64,
-                                                           index::onemklIndex,
+                                                           nnz::Int64, index::onemklIndex,
                                                            row_ptr::ZePtr{Int64},
                                                            col_ind::ZePtr{Int64},
                                                            values::ZePtr{Cdouble})::Cint
 end
 
-function onemklCsparse_set_csr_data(device_queue, spMat, nrows, ncols, index, row_ptr,
+function onemklCsparse_set_csr_data(device_queue, spmat, nrows, ncols, nnz, index, row_ptr,
                                     col_ind, values)
     @ccall liboneapi_support.onemklCsparse_set_csr_data(device_queue::syclQueue_t,
-                                                        spMat::matrix_handle_t,
-                                                        nrows::Int32, ncols::Int32,
-                                                        index::onemklIndex,
+                                                        spmat::matrix_handle_t,
+                                                        nrows::Int64, ncols::Int64,
+                                                        nnz::Int64, index::onemklIndex,
                                                         row_ptr::ZePtr{Int32},
                                                         col_ind::ZePtr{Int32},
                                                         values::ZePtr{ComplexF32})::Cint
 end
 
-function onemklCsparse_set_csr_data_64(device_queue, spMat, nrows, ncols, index, row_ptr,
-                                       col_ind, values)
+function onemklCsparse_set_csr_data_64(device_queue, spmat, nrows, ncols, nnz, index,
+                                       row_ptr, col_ind, values)
     @ccall liboneapi_support.onemklCsparse_set_csr_data_64(device_queue::syclQueue_t,
-                                                           spMat::matrix_handle_t,
+                                                           spmat::matrix_handle_t,
                                                            nrows::Int64, ncols::Int64,
-                                                           index::onemklIndex,
+                                                           nnz::Int64, index::onemklIndex,
                                                            row_ptr::ZePtr{Int64},
                                                            col_ind::ZePtr{Int64},
                                                            values::ZePtr{ComplexF32})::Cint
 end
 
-function onemklZsparse_set_csr_data(device_queue, spMat, nrows, ncols, index, row_ptr,
+function onemklZsparse_set_csr_data(device_queue, spmat, nrows, ncols, nnz, index, row_ptr,
                                     col_ind, values)
     @ccall liboneapi_support.onemklZsparse_set_csr_data(device_queue::syclQueue_t,
-                                                        spMat::matrix_handle_t,
-                                                        nrows::Int32, ncols::Int32,
-                                                        index::onemklIndex,
+                                                        spmat::matrix_handle_t,
+                                                        nrows::Int64, ncols::Int64,
+                                                        nnz::Int64, index::onemklIndex,
                                                         row_ptr::ZePtr{Int32},
                                                         col_ind::ZePtr{Int32},
                                                         values::ZePtr{ComplexF64})::Cint
 end
 
-function onemklZsparse_set_csr_data_64(device_queue, spMat, nrows, ncols, index, row_ptr,
-                                       col_ind, values)
+function onemklZsparse_set_csr_data_64(device_queue, spmat, nrows, ncols, nnz, index,
+                                       row_ptr, col_ind, values)
     @ccall liboneapi_support.onemklZsparse_set_csr_data_64(device_queue::syclQueue_t,
-                                                           spMat::matrix_handle_t,
+                                                           spmat::matrix_handle_t,
                                                            nrows::Int64, ncols::Int64,
-                                                           index::onemklIndex,
+                                                           nnz::Int64, index::onemklIndex,
                                                            row_ptr::ZePtr{Int64},
                                                            col_ind::ZePtr{Int64},
                                                            values::ZePtr{ComplexF64})::Cint
 end
 
-function onemklSsparse_set_coo_data(device_queue, spMat, nrows, ncols, nnz, index, row_ind,
+function onemklSsparse_set_csc_data(device_queue, spMat, nrows, ncols, nnz, index, col_ptr,
+                                    row_ind, values)
+    @ccall liboneapi_support.onemklSsparse_set_csc_data(device_queue::syclQueue_t,
+                                                        spMat::matrix_handle_t,
+                                                        nrows::Int64, ncols::Int64,
+                                                        nnz::Int64, index::onemklIndex,
+                                                        col_ptr::Ptr{Int32},
+                                                        row_ind::Ptr{Int32},
+                                                        values::Ptr{Cfloat})::Cint
+end
+
+function onemklSsparse_set_csc_data_64(device_queue, spMat, nrows, ncols, nnz, index,
+                                       col_ptr, row_ind, values)
+    @ccall liboneapi_support.onemklSsparse_set_csc_data_64(device_queue::syclQueue_t,
+                                                           spMat::matrix_handle_t,
+                                                           nrows::Int64, ncols::Int64,
+                                                           nnz::Int64, index::onemklIndex,
+                                                           col_ptr::Ptr{Int64},
+                                                           row_ind::Ptr{Int64},
+                                                           values::Ptr{Cfloat})::Cint
+end
+
+function onemklDsparse_set_csc_data(device_queue, spMat, nrows, ncols, nnz, index, col_ptr,
+                                    row_ind, values)
+    @ccall liboneapi_support.onemklDsparse_set_csc_data(device_queue::syclQueue_t,
+                                                        spMat::matrix_handle_t,
+                                                        nrows::Int64, ncols::Int64,
+                                                        nnz::Int64, index::onemklIndex,
+                                                        col_ptr::Ptr{Int32},
+                                                        row_ind::Ptr{Int32},
+                                                        values::Ptr{Cdouble})::Cint
+end
+
+function onemklDsparse_set_csc_data_64(device_queue, spMat, nrows, ncols, nnz, index,
+                                       col_ptr, row_ind, values)
+    @ccall liboneapi_support.onemklDsparse_set_csc_data_64(device_queue::syclQueue_t,
+                                                           spMat::matrix_handle_t,
+                                                           nrows::Int64, ncols::Int64,
+                                                           nnz::Int64, index::onemklIndex,
+                                                           col_ptr::Ptr{Int64},
+                                                           row_ind::Ptr{Int64},
+                                                           values::Ptr{Cdouble})::Cint
+end
+
+function onemklCsparse_set_csc_data(device_queue, spMat, nrows, ncols, nnz, index, col_ptr,
+                                    row_ind, values)
+    @ccall liboneapi_support.onemklCsparse_set_csc_data(device_queue::syclQueue_t,
+                                                        spMat::matrix_handle_t,
+                                                        nrows::Int64, ncols::Int64,
+                                                        nnz::Int64, index::onemklIndex,
+                                                        col_ptr::Ptr{Int32},
+                                                        row_ind::Ptr{Int32},
+                                                        values::Ptr{ComplexF32})::Cint
+end
+
+function onemklCsparse_set_csc_data_64(device_queue, spMat, nrows, ncols, nnz, index,
+                                       col_ptr, row_ind, values)
+    @ccall liboneapi_support.onemklCsparse_set_csc_data_64(device_queue::syclQueue_t,
+                                                           spMat::matrix_handle_t,
+                                                           nrows::Int64, ncols::Int64,
+                                                           nnz::Int64, index::onemklIndex,
+                                                           col_ptr::Ptr{Int64},
+                                                           row_ind::Ptr{Int64},
+                                                           values::Ptr{ComplexF32})::Cint
+end
+
+function onemklZsparse_set_csc_data(device_queue, spMat, nrows, ncols, nnz, index, col_ptr,
+                                    row_ind, values)
+    @ccall liboneapi_support.onemklZsparse_set_csc_data(device_queue::syclQueue_t,
+                                                        spMat::matrix_handle_t,
+                                                        nrows::Int64, ncols::Int64,
+                                                        nnz::Int64, index::onemklIndex,
+                                                        col_ptr::Ptr{Int32},
+                                                        row_ind::Ptr{Int32},
+                                                        values::Ptr{ComplexF32})::Cint
+end
+
+function onemklZsparse_set_csc_data_64(device_queue, spMat, nrows, ncols, nnz, index,
+                                       col_ptr, row_ind, values)
+    @ccall liboneapi_support.onemklZsparse_set_csc_data_64(device_queue::syclQueue_t,
+                                                           spMat::matrix_handle_t,
+                                                           nrows::Int64, ncols::Int64,
+                                                           nnz::Int64, index::onemklIndex,
+                                                           col_ptr::Ptr{Int64},
+                                                           row_ind::Ptr{Int64},
+                                                           values::Ptr{ComplexF32})::Cint
+end
+
+function onemklSsparse_set_coo_data(device_queue, spmat, nrows, ncols, nnz, index, row_ind,
                                     col_ind, values)
     @ccall liboneapi_support.onemklSsparse_set_coo_data(device_queue::syclQueue_t,
-                                                        spMat::matrix_handle_t,
+                                                        spmat::matrix_handle_t,
                                                         nrows::Int32, ncols::Int32,
                                                         nnz::Int32, index::onemklIndex,
                                                         row_ind::ZePtr{Int32},
@@ -6536,10 +6624,10 @@ function onemklSsparse_set_coo_data(device_queue, spMat, nrows, ncols, nnz, inde
                                                         values::ZePtr{Cfloat})::Cint
 end
 
-function onemklSsparse_set_coo_data_64(device_queue, spMat, nrows, ncols, nnz, index,
+function onemklSsparse_set_coo_data_64(device_queue, spmat, nrows, ncols, nnz, index,
                                        row_ind, col_ind, values)
     @ccall liboneapi_support.onemklSsparse_set_coo_data_64(device_queue::syclQueue_t,
-                                                           spMat::matrix_handle_t,
+                                                           spmat::matrix_handle_t,
                                                            nrows::Int64, ncols::Int64,
                                                            nnz::Int64, index::onemklIndex,
                                                            row_ind::ZePtr{Int64},
@@ -6547,10 +6635,10 @@ function onemklSsparse_set_coo_data_64(device_queue, spMat, nrows, ncols, nnz, i
                                                            values::ZePtr{Cfloat})::Cint
 end
 
-function onemklDsparse_set_coo_data(device_queue, spMat, nrows, ncols, nnz, index, row_ind,
+function onemklDsparse_set_coo_data(device_queue, spmat, nrows, ncols, nnz, index, row_ind,
                                     col_ind, values)
     @ccall liboneapi_support.onemklDsparse_set_coo_data(device_queue::syclQueue_t,
-                                                        spMat::matrix_handle_t,
+                                                        spmat::matrix_handle_t,
                                                         nrows::Int32, ncols::Int32,
                                                         nnz::Int32, index::onemklIndex,
                                                         row_ind::ZePtr{Int32},
@@ -6558,10 +6646,10 @@ function onemklDsparse_set_coo_data(device_queue, spMat, nrows, ncols, nnz, inde
                                                         values::ZePtr{Cdouble})::Cint
 end
 
-function onemklDsparse_set_coo_data_64(device_queue, spMat, nrows, ncols, nnz, index,
+function onemklDsparse_set_coo_data_64(device_queue, spmat, nrows, ncols, nnz, index,
                                        row_ind, col_ind, values)
     @ccall liboneapi_support.onemklDsparse_set_coo_data_64(device_queue::syclQueue_t,
-                                                           spMat::matrix_handle_t,
+                                                           spmat::matrix_handle_t,
                                                            nrows::Int64, ncols::Int64,
                                                            nnz::Int64, index::onemklIndex,
                                                            row_ind::ZePtr{Int64},
@@ -6569,10 +6657,10 @@ function onemklDsparse_set_coo_data_64(device_queue, spMat, nrows, ncols, nnz, i
                                                            values::ZePtr{Cdouble})::Cint
 end
 
-function onemklCsparse_set_coo_data(device_queue, spMat, nrows, ncols, nnz, index, row_ind,
+function onemklCsparse_set_coo_data(device_queue, spmat, nrows, ncols, nnz, index, row_ind,
                                     col_ind, values)
     @ccall liboneapi_support.onemklCsparse_set_coo_data(device_queue::syclQueue_t,
-                                                        spMat::matrix_handle_t,
+                                                        spmat::matrix_handle_t,
                                                         nrows::Int32, ncols::Int32,
                                                         nnz::Int32, index::onemklIndex,
                                                         row_ind::ZePtr{Int32},
@@ -6580,10 +6668,10 @@ function onemklCsparse_set_coo_data(device_queue, spMat, nrows, ncols, nnz, inde
                                                         values::ZePtr{ComplexF32})::Cint
 end
 
-function onemklCsparse_set_coo_data_64(device_queue, spMat, nrows, ncols, nnz, index,
+function onemklCsparse_set_coo_data_64(device_queue, spmat, nrows, ncols, nnz, index,
                                        row_ind, col_ind, values)
     @ccall liboneapi_support.onemklCsparse_set_coo_data_64(device_queue::syclQueue_t,
-                                                           spMat::matrix_handle_t,
+                                                           spmat::matrix_handle_t,
                                                            nrows::Int64, ncols::Int64,
                                                            nnz::Int64, index::onemklIndex,
                                                            row_ind::ZePtr{Int64},
@@ -6591,10 +6679,10 @@ function onemklCsparse_set_coo_data_64(device_queue, spMat, nrows, ncols, nnz, i
                                                            values::ZePtr{ComplexF32})::Cint
 end
 
-function onemklZsparse_set_coo_data(device_queue, spMat, nrows, ncols, nnz, index, row_ind,
+function onemklZsparse_set_coo_data(device_queue, spmat, nrows, ncols, nnz, index, row_ind,
                                     col_ind, values)
     @ccall liboneapi_support.onemklZsparse_set_coo_data(device_queue::syclQueue_t,
-                                                        spMat::matrix_handle_t,
+                                                        spmat::matrix_handle_t,
                                                         nrows::Int32, ncols::Int32,
                                                         nnz::Int32, index::onemklIndex,
                                                         row_ind::ZePtr{Int32},
@@ -6602,15 +6690,139 @@ function onemklZsparse_set_coo_data(device_queue, spMat, nrows, ncols, nnz, inde
                                                         values::ZePtr{ComplexF64})::Cint
 end
 
-function onemklZsparse_set_coo_data_64(device_queue, spMat, nrows, ncols, nnz, index,
+function onemklZsparse_set_coo_data_64(device_queue, spmat, nrows, ncols, nnz, index,
                                        row_ind, col_ind, values)
     @ccall liboneapi_support.onemklZsparse_set_coo_data_64(device_queue::syclQueue_t,
-                                                           spMat::matrix_handle_t,
+                                                           spmat::matrix_handle_t,
                                                            nrows::Int64, ncols::Int64,
                                                            nnz::Int64, index::onemklIndex,
                                                            row_ind::ZePtr{Int64},
                                                            col_ind::ZePtr{Int64},
                                                            values::ZePtr{ComplexF64})::Cint
+end
+
+function onemklSsparse_set_bsr_data(device_queue, spmat, blk_nrows, blk_ncols, blk_nnz,
+                                    row_blk_size, col_blk_size, blk_layout, index,
+                                    bsr_row_ptr, bsr_col_ind, bsr_values)
+    @ccall liboneapi_support.onemklSsparse_set_bsr_data(device_queue::syclQueue_t,
+                                                        spmat::matrix_handle_t,
+                                                        blk_nrows::Int64, blk_ncols::Int64,
+                                                        blk_nnz::Int64, row_blk_size::Int64,
+                                                        col_blk_size::Int64,
+                                                        blk_layout::onemklLayout,
+                                                        index::onemklIndex,
+                                                        bsr_row_ptr::Ptr{Int32},
+                                                        bsr_col_ind::Ptr{Int32},
+                                                        bsr_values::Ptr{Cfloat})::Cint
+end
+
+function onemklSsparse_set_bsr_data_64(device_queue, spmat, blk_nrows, blk_ncols, blk_nnz,
+                                       row_blk_size, col_blk_size, blk_layout, index,
+                                       bsr_row_ptr, bsr_col_ind, bsr_values)
+    @ccall liboneapi_support.onemklSsparse_set_bsr_data_64(device_queue::syclQueue_t,
+                                                           spmat::matrix_handle_t,
+                                                           blk_nrows::Int64,
+                                                           blk_ncols::Int64, blk_nnz::Int64,
+                                                           row_blk_size::Int64,
+                                                           col_blk_size::Int64,
+                                                           blk_layout::onemklLayout,
+                                                           index::onemklIndex,
+                                                           bsr_row_ptr::Ptr{Int64},
+                                                           bsr_col_ind::Ptr{Int64},
+                                                           bsr_values::Ptr{Cfloat})::Cint
+end
+
+function onemklDsparse_set_bsr_data(device_queue, spmat, blk_nrows, blk_ncols, blk_nnz,
+                                    row_blk_size, col_blk_size, blk_layout, index,
+                                    bsr_row_ptr, bsr_col_ind, bsr_values)
+    @ccall liboneapi_support.onemklDsparse_set_bsr_data(device_queue::syclQueue_t,
+                                                        spmat::matrix_handle_t,
+                                                        blk_nrows::Int64, blk_ncols::Int64,
+                                                        blk_nnz::Int64, row_blk_size::Int64,
+                                                        col_blk_size::Int64,
+                                                        blk_layout::onemklLayout,
+                                                        index::onemklIndex,
+                                                        bsr_row_ptr::Ptr{Int32},
+                                                        bsr_col_ind::Ptr{Int32},
+                                                        bsr_values::Ptr{Cdouble})::Cint
+end
+
+function onemklDsparse_set_bsr_data_64(device_queue, spmat, blk_nrows, blk_ncols, blk_nnz,
+                                       row_blk_size, col_blk_size, blk_layout, index,
+                                       bsr_row_ptr, bsr_col_ind, bsr_values)
+    @ccall liboneapi_support.onemklDsparse_set_bsr_data_64(device_queue::syclQueue_t,
+                                                           spmat::matrix_handle_t,
+                                                           blk_nrows::Int64,
+                                                           blk_ncols::Int64, blk_nnz::Int64,
+                                                           row_blk_size::Int64,
+                                                           col_blk_size::Int64,
+                                                           blk_layout::onemklLayout,
+                                                           index::onemklIndex,
+                                                           bsr_row_ptr::Ptr{Int64},
+                                                           bsr_col_ind::Ptr{Int64},
+                                                           bsr_values::Ptr{Cdouble})::Cint
+end
+
+function onemklCsparse_set_bsr_data(device_queue, spmat, blk_nrows, blk_ncols, blk_nnz,
+                                    row_blk_size, col_blk_size, blk_layout, index,
+                                    bsr_row_ptr, bsr_col_ind, bsr_values)
+    @ccall liboneapi_support.onemklCsparse_set_bsr_data(device_queue::syclQueue_t,
+                                                        spmat::matrix_handle_t,
+                                                        blk_nrows::Int64, blk_ncols::Int64,
+                                                        blk_nnz::Int64, row_blk_size::Int64,
+                                                        col_blk_size::Int64,
+                                                        blk_layout::onemklLayout,
+                                                        index::onemklIndex,
+                                                        bsr_row_ptr::Ptr{Int32},
+                                                        bsr_col_ind::Ptr{Int32},
+                                                        bsr_values::Ptr{ComplexF32})::Cint
+end
+
+function onemklCsparse_set_bsr_data_64(device_queue, spmat, blk_nrows, blk_ncols, blk_nnz,
+                                       row_blk_size, col_blk_size, blk_layout, index,
+                                       bsr_row_ptr, bsr_col_ind, bsr_values)
+    @ccall liboneapi_support.onemklCsparse_set_bsr_data_64(device_queue::syclQueue_t,
+                                                           spmat::matrix_handle_t,
+                                                           blk_nrows::Int64,
+                                                           blk_ncols::Int64, blk_nnz::Int64,
+                                                           row_blk_size::Int64,
+                                                           col_blk_size::Int64,
+                                                           blk_layout::onemklLayout,
+                                                           index::onemklIndex,
+                                                           bsr_row_ptr::Ptr{Int64},
+                                                           bsr_col_ind::Ptr{Int64},
+                                                           bsr_values::Ptr{ComplexF32})::Cint
+end
+
+function onemklZsparse_set_bsr_data(device_queue, spmat, blk_nrows, blk_ncols, blk_nnz,
+                                    row_blk_size, col_blk_size, blk_layout, index,
+                                    bsr_row_ptr, bsr_col_ind, bsr_values)
+    @ccall liboneapi_support.onemklZsparse_set_bsr_data(device_queue::syclQueue_t,
+                                                        spmat::matrix_handle_t,
+                                                        blk_nrows::Int64, blk_ncols::Int64,
+                                                        blk_nnz::Int64, row_blk_size::Int64,
+                                                        col_blk_size::Int64,
+                                                        blk_layout::onemklLayout,
+                                                        index::onemklIndex,
+                                                        bsr_row_ptr::Ptr{Int32},
+                                                        bsr_col_ind::Ptr{Int32},
+                                                        bsr_values::Ptr{ComplexF32})::Cint
+end
+
+function onemklZsparse_set_bsr_data_64(device_queue, spmat, blk_nrows, blk_ncols, blk_nnz,
+                                       row_blk_size, col_blk_size, blk_layout, index,
+                                       bsr_row_ptr, bsr_col_ind, bsr_values)
+    @ccall liboneapi_support.onemklZsparse_set_bsr_data_64(device_queue::syclQueue_t,
+                                                           spmat::matrix_handle_t,
+                                                           blk_nrows::Int64,
+                                                           blk_ncols::Int64, blk_nnz::Int64,
+                                                           row_blk_size::Int64,
+                                                           col_blk_size::Int64,
+                                                           blk_layout::onemklLayout,
+                                                           index::onemklIndex,
+                                                           bsr_row_ptr::Ptr{Int64},
+                                                           bsr_col_ind::Ptr{Int64},
+                                                           bsr_values::Ptr{ComplexF32})::Cint
 end
 
 function onemklXsparse_init_matmat_descr(p_desc)

--- a/res/support.toml
+++ b/res/support.toml
@@ -370,15 +370,17 @@ use_ccall_macro = true
 6 = "ZePtr{Float32}"
 8 = "Ref{Float32}"
 
+# Argument positions account for the `nnz` parameter (arg 5) and the
+# `index::onemklIndex` enum (arg 6); the device pointers are args 7-9.
 [api.onemklXsparse_set_csr_data.argtypes]
-6 = "ZePtr{Int32}"
 7 = "ZePtr{Int32}"
-8 = "ZePtr{T}"
+8 = "ZePtr{Int32}"
+9 = "ZePtr{T}"
 
 [api.onemklXsparse_set_csr_data_64.argtypes]
-6 = "ZePtr{Int64}"
 7 = "ZePtr{Int64}"
-8 = "ZePtr{T}"
+8 = "ZePtr{Int64}"
+9 = "ZePtr{T}"
 
 [api.onemklXsparse_set_coo_data.argtypes]
 7 = "ZePtr{Int32}"

--- a/test/onemkl.jl
+++ b/test/onemkl.jl
@@ -12,9 +12,16 @@ m = 20
 n = 35
 k = 13
 
+# CSC construction requires a support library built against oneMKL 2025.3+ (wide sparse ABI)
+csc_supported = oneMKL.csc_supported()
+csr_csc_matrices = csc_supported ? (oneSparseMatrixCSR, oneSparseMatrixCSC) :
+    (oneSparseMatrixCSR,)
+coo_csr_csc_matrices = csc_supported ? (oneSparseMatrixCOO, oneSparseMatrixCSR, oneSparseMatrixCSC) :
+    (oneSparseMatrixCOO, oneSparseMatrixCSR)
+
 @testset "Version" begin
     version_onemkl = oneMKL.version()
-    @test version_onemkl ≥ v"2026.0.0"
+    @test version_onemkl ≥ v"2025.2.0"
 end
 
 ############################################################################################
@@ -1098,6 +1105,7 @@ end
         end
 
             @testset "oneSparseMatrixCSC" begin
+                csc_supported || continue
                 (T isa Complex) && continue
                 for S in (Int32, Int64)
                     A = sprand(T, 20, 10, 0.5)
@@ -1123,7 +1131,7 @@ end
         end
 
         @testset "sparse gemv" begin
-                @testset  "$SparseMatrix" for SparseMatrix in (oneSparseMatrixCOO, oneSparseMatrixCSR, oneSparseMatrixCSC)
+                @testset  "$SparseMatrix" for SparseMatrix in coo_csr_csc_matrices
                     @testset "transa = $transa" for (transa, opa) in [('N', identity), ('T', transpose), ('C', adjoint)]
                     A = sprand(T, 20, 10, 0.5)
                     x = transa == 'N' ? rand(T, 10) : rand(T, 20)
@@ -1143,7 +1151,7 @@ end
         end
 
         @testset "sparse gemm" begin
-                @testset  "$SparseMatrix" for SparseMatrix in (oneSparseMatrixCSR, oneSparseMatrixCSC)
+                @testset  "$SparseMatrix" for SparseMatrix in csr_csc_matrices
                     @testset "transa = $transa" for (transa, opa) in [('N', identity), ('T', transpose), ('C', adjoint)]
                         @testset "transb = $transb" for (transb, opb) in [('N', identity), ('T', transpose), ('C', adjoint)]
                             (transb == 'N') || continue
@@ -1168,7 +1176,7 @@ end
         end
 
         @testset "sparse symv" begin
-                @testset  "$SparseMatrix" for SparseMatrix in (oneSparseMatrixCSR, oneSparseMatrixCSC)
+                @testset  "$SparseMatrix" for SparseMatrix in csr_csc_matrices
                     @testset "uplo = $uplo" for uplo in ('L', 'U')
                     A = sprand(T, 10, 10, 0.5)
                     A = A + transpose(A)
@@ -1188,7 +1196,7 @@ end
         end
 
             @testset "sparse trmv" begin
-                @testset  "$SparseMatrix" for SparseMatrix in (oneSparseMatrixCSR, oneSparseMatrixCSC)
+                @testset  "$SparseMatrix" for SparseMatrix in csr_csc_matrices
                     @testset "transa = $transa" for (transa, opa) in [('N', identity), ('T', transpose), ('C', adjoint)]
                         for (uplo, diag, wrapper) in [
                                 ('L', 'N', LowerTriangular), ('L', 'U', UnitLowerTriangular),
@@ -1223,7 +1231,7 @@ end
         end
 
             @testset "sparse trsv" begin
-                @testset  "$SparseMatrix" for SparseMatrix in (oneSparseMatrixCSR, oneSparseMatrixCSC)
+                @testset  "$SparseMatrix" for SparseMatrix in csr_csc_matrices
                     @testset "transa = $transa" for (transa, opa) in [('N', identity), ('T', transpose), ('C', adjoint)]
                     for (uplo, diag, wrapper) in [('L', 'N', LowerTriangular), ('L', 'U', UnitLowerTriangular),
                                 ('U', 'N', UpperTriangular), ('U', 'U', UnitUpperTriangular),
@@ -1257,7 +1265,7 @@ end
             end
 
             @testset "sparse trsm" begin
-                @testset  "$SparseMatrix" for SparseMatrix in (oneSparseMatrixCSR, oneSparseMatrixCSC)
+                @testset  "$SparseMatrix" for SparseMatrix in csr_csc_matrices
                     @testset "transa = $transa" for (transa, opa) in [('N', identity), ('T', transpose), ('C', adjoint)]
                         @testset "transx = $transx" for (transx, opx) in [('N', identity), ('T', transpose), ('C', adjoint)]
                             (transx != 'N') && continue


### PR DESCRIPTION
oneMKL 2025.3 widened the sparse setter ABI: set_{csr,coo}_data take an explicit nnz and 64-bit dimensions, set_csc_data/set_bsr_data are new, and the pre-2025.3 setter overloads are deprecated (though still present in 2026.x). Regenerate the C wrappers and Julia bindings against the 2025.3.1 headers and adopt the wide ABI throughout:

- generate_interfaces.jl pulls the headers from oneAPI_Support_Headers_jll =2025.3.1, dedups the deprecated/new overload pairs (keeping the wider signature), normalizes the spMat/spmat parameter naming, and no longer bakes version constants into onemkl.h.
- onemkl_version() reports the oneMKL the library was built against (from mkl_version.h) instead of generation-time constants.
- build_local.jl derives the Conda toolkit version from the headers JLL instead of hardcoding it, keying the Conda scratch per version.
- The sparse wrappers pass nnz explicitly; oneSparseMatrixCSC raises a clear error when the loaded support library predates oneMKL 2025.3 (its CSC setters only exist there), and the tests skip CSC accordingly.
- Support.jl probes the loaded binary for the wide sparse ABI at load time: the oneAPI_Support_jll 0.9.2 artifact predates it, and calling the regenerated setters against it would corrupt memory or crash.