### PR TITLE
Fix sparse CSC matrix multiplication

### DIFF
--- a/lib/mkl/interfaces.jl
+++ b/lib/mkl/interfaces.jl
@@ -18,7 +18,8 @@ function LinearAlgebra.generic_matvecmul!(C::oneVector{T}, tA::AbstractChar, A::
 end
 
 function LinearAlgebra.generic_matvecmul!(C::oneVector{T}, tA::AbstractChar, A::oneSparseMatrixCSC{T}, B::oneVector{T}, alpha::Number, beta::Number) where {T <: BlasReal}
-    tA = tA in ('S', 's', 'H', 'h') ? 'T' : flip_trans(tA)
+    # sparse_gemv! already maps op(A) onto the transposed CSR handle, so tA is passed through
+    tA = tA in ('S', 's', 'H', 'h') ? 'N' : tA
     return sparse_gemv!(tA, alpha, A, B, beta, C)
 end
 
@@ -29,7 +30,8 @@ function LinearAlgebra.generic_matmatmul!(C::oneMatrix{T}, tA, tB, A::oneSparseM
 end
 
 function LinearAlgebra.generic_matmatmul!(C::oneMatrix{T}, tA, tB, A::oneSparseMatrixCSC{T}, B::oneMatrix{T}, alpha::Number, beta::Number) where {T <: BlasReal}
-    tA = tA in ('S', 's', 'H', 'h') ? 'T' : flip_trans(tA)
+    # sparse_gemm! already maps op(A) onto the transposed CSR handle, so tA is passed through
+    tA = tA in ('S', 's', 'H', 'h') ? 'N' : tA
     tB = tB in ('S', 's', 'H', 'h') ? 'N' : tB
     return sparse_gemm!(tA, tB, alpha, A, B, beta, C)
 end

--- a/lib/mkl/interfaces.jl
+++ b/lib/mkl/interfaces.jl
@@ -17,7 +17,7 @@ function LinearAlgebra.generic_matvecmul!(C::oneVector{T}, tA::AbstractChar, A::
     return sparse_gemv!(tA, alpha, A, B, beta, C)
 end
 
-function LinearAlgebra.generic_matvecmul!(C::oneVector{T}, tA::AbstractChar, A::oneSparseMatrixCSC{T}, B::oneVector{T}, alpha::Number, beta::Number) where {T <: BlasReal}
+function LinearAlgebra.generic_matvecmul!(C::oneVector{T}, tA::AbstractChar, A::oneSparseMatrixCSC{T}, B::oneVector{T}, alpha::Number, beta::Number) where {T <: BlasFloat}
     # sparse_gemv! already maps op(A) onto the transposed CSR handle, so tA is passed through
     tA = tA in ('S', 's', 'H', 'h') ? 'N' : tA
     return sparse_gemv!(tA, alpha, A, B, beta, C)
@@ -29,7 +29,7 @@ function LinearAlgebra.generic_matmatmul!(C::oneMatrix{T}, tA, tB, A::oneSparseM
     return sparse_gemm!(tA, tB, alpha, A, B, beta, C)
 end
 
-function LinearAlgebra.generic_matmatmul!(C::oneMatrix{T}, tA, tB, A::oneSparseMatrixCSC{T}, B::oneMatrix{T}, alpha::Number, beta::Number) where {T <: BlasReal}
+function LinearAlgebra.generic_matmatmul!(C::oneMatrix{T}, tA, tB, A::oneSparseMatrixCSC{T}, B::oneMatrix{T}, alpha::Number, beta::Number) where {T <: BlasFloat}
     # sparse_gemm! already maps op(A) onto the transposed CSR handle, so tA is passed through
     tA = tA in ('S', 's', 'H', 'h') ? 'N' : tA
     tB = tB in ('S', 's', 'H', 'h') ? 'N' : tB

--- a/test/onemkl.jl
+++ b/test/onemkl.jl
@@ -1179,9 +1179,6 @@ end
             # a separate mapping from the sparse_gemv!/sparse_gemm! calls exercised above
             @testset "sparse LinearAlgebra mul" begin
                 @testset "$SparseMatrix" for SparseMatrix in csr_csc_matrices
-                    # the CSC methods are restricted to real element types
-                    (SparseMatrix == oneSparseMatrixCSC && T <: Complex) && continue
-
                     A = sprand(T, 10, 10, 0.5)
                     x = rand(T, 10)
                     y = rand(T, 10)
@@ -1192,10 +1189,10 @@ end
                     dx = oneVector{T}(x)
                     dB = oneMatrix{T}(B)
 
-                    @test A * x ≈ collect(dA * dx)
-                    @test A * B ≈ collect(dA * dB)
-                    @test transpose(A) * x ≈ collect(transpose(dA) * dx)
-                    @test transpose(A) * B ≈ collect(transpose(dA) * dB)
+                    @testset "opa = $(nameof(opa))" for opa in (identity, transpose, adjoint)
+                        @test opa(A) * x ≈ collect(opa(dA) * dx)
+                        @test opa(A) * B ≈ collect(opa(dA) * dB)
+                    end
 
                     alpha = rand(T)
                     beta = rand(T)

--- a/test/onemkl.jl
+++ b/test/onemkl.jl
@@ -1175,6 +1175,35 @@ end
             end
         end
 
+            # `*` and `mul!` reach oneMKL through generic_matvecmul!/generic_matmatmul!, which is
+            # a separate mapping from the sparse_gemv!/sparse_gemm! calls exercised above
+            @testset "sparse LinearAlgebra mul" begin
+                @testset "$SparseMatrix" for SparseMatrix in csr_csc_matrices
+                    # the CSC methods are restricted to real element types
+                    (SparseMatrix == oneSparseMatrixCSC && T <: Complex) && continue
+
+                    A = sprand(T, 10, 10, 0.5)
+                    x = rand(T, 10)
+                    y = rand(T, 10)
+                    B = rand(T, 10, 2)
+                    C = rand(T, 10, 2)
+
+                    dA = SparseMatrix(A)
+                    dx = oneVector{T}(x)
+                    dB = oneMatrix{T}(B)
+
+                    @test A * x ≈ collect(dA * dx)
+                    @test A * B ≈ collect(dA * dB)
+                    @test transpose(A) * x ≈ collect(transpose(dA) * dx)
+                    @test transpose(A) * B ≈ collect(transpose(dA) * dB)
+
+                    alpha = rand(T)
+                    beta = rand(T)
+                    @test alpha * A * x + beta * y ≈ collect(mul!(oneVector{T}(y), dA, dx, alpha, beta))
+                    @test alpha * A * B + beta * C ≈ collect(mul!(oneMatrix{T}(C), dA, dB, alpha, beta))
+                end
+            end
+
         @testset "sparse symv" begin
                 @testset  "$SparseMatrix" for SparseMatrix in csr_csc_matrices
                     @testset "uplo = $uplo" for uplo in ('L', 'U')


### PR DESCRIPTION
Two fixes to sparse CSC multiplication through the `LinearAlgebra` interface.

**Transposed result.** `dA * x` returned `Aᵀx` for a `oneSparseMatrixCSC` (same for `dA * B` and `mul!`). A CSC handle stores `CSR(Aᵀ)`, so `sparse_gemv!`/`sparse_gemm!` already apply `flip_trans` internally. `generic_matvecmul!`/`generic_matmatmul!` applied it a second time, so the two cancelled and oneMKL computed `S*x = Aᵀx`. CSR was unaffected.

**Complex element types.** The CSC methods were constrained to `BlasReal`, so complex CSC never reached them and failed with `CanonicalIndexError: getindex not defined`. The underlying wrappers already have complex CSC specializations handling the `'C'` conjugation identities, so widening to `BlasFloat` to match CSR is sufficient.

