### PR TITLE
Use host USM for scalar oneMKL results

### DIFF
--- a/lib/mkl/utils.jl
+++ b/lib/mkl/utils.jl
@@ -108,6 +108,18 @@ function Base.convert(::Type{onemklRangev}, range::Char)
     end
 end
 
+# Allocate a one-element buffer for a scalar oneMKL output (nrm2, dot, asum, iamax,
+# iamin). These are written by the device but consumed on the host, so we place them in
+# host USM: oneMKL writes straight into host-visible memory and we read the value with a
+# plain load, instead of allocating a device buffer and copying it back. The C wrappers
+# synchronize the queue before returning, so the result is readable as soon as the
+# `ccall` does.
+function scalar_result(::Type{T}) where {T}
+    res = oneArray{T, 1, oneL0.HostBuffer}(undef, 1)
+    res[1] = zero(T)
+    return res
+end
+
 # create a batch of pointers in device memory from a batch of device arrays
 @inline function unsafe_batch(batch::Vector{<:oneArray{T}}) where {T}
     ptrs = pointer.(batch)

--- a/lib/mkl/wrappers_blas.jl
+++ b/lib/mkl/wrappers_blas.jl
@@ -587,10 +587,9 @@ for (fname, elty, ret_type) in
     @eval begin
         function nrm2(n::Integer, x::oneStridedArray{$elty})
             queue = global_queue(context(x), device(x))
-            result = oneArray{$ret_type}([0]);
+            result = scalar_result($ret_type)
             $fname(sycl_queue(queue), n, x, stride(x,1), result)
-            res = Array(result)
-            return res[1]
+            return result[1]
         end
     end
 end
@@ -617,10 +616,9 @@ for (jname, fname, elty) in
                          x::oneStridedArray{$elty},
                          y::oneStridedArray{$elty})
             queue = global_queue(context(x), device(x))
-            result = oneArray{$elty}([0]);
+            result = scalar_result($elty)
             $fname(sycl_queue(queue), n, x, stride(x,1), y, stride(y,1), result)
-            res = Array(result)
-            return res[1]
+            return result[1]
         end
     end
 end
@@ -806,11 +804,10 @@ for (fname, elty, ret_type) in
     @eval begin
         function asum(n::Integer,
                       x::oneStridedArray{$elty})
-            result = oneArray{$ret_type}([0])
+            result = scalar_result($ret_type)
             queue = global_queue(context(x), device(x))
             $fname(sycl_queue(queue), n, x, stride(x, 1), result)
-            res = Array(result)
-            return res[1]
+            return result[1]
         end
     end
 end
@@ -825,9 +822,9 @@ for (fname, elty) in
         function iamax(x::oneStridedArray{$elty})
             n = length(x)
             queue = global_queue(context(x), device(x))
-            result = oneArray{Int64}([0]);
+            result = scalar_result(Int64)
             $fname(sycl_queue(queue), n, x, stride(x, 1), result, 'O')
-            return Array(result)[1]
+            return result[1]
         end
     end
 end
@@ -841,10 +838,10 @@ for (fname, elty) in
     @eval begin
         function iamin(x::StridedArray{$elty})
             n = length(x)
-            result = oneArray{Int64}([0]);
+            result = scalar_result(Int64)
             queue = global_queue(context(x), device(x))
             $fname(sycl_queue(queue),n, x, stride(x, 1), result, 'O')
-            return Array(result)[1]
+            return result[1]
         end
     end
 end


### PR DESCRIPTION
Closes #234.

The scalar-returning oneMKL BLAS wrappers hand the library a one-element **device** `oneArray` and copy the value back:

```julia
result = oneArray{$ret_type}([0])   # host vector -> device (H2D)
$fname(sycl_queue(queue), n, x, stride(x,1), result)
res = Array(result)                 # device -> host (D2H)
return res[1]
```

The two transfers dominate the call. Since we now support host-USM-backed arrays (`oneArray{T,N,oneL0.HostBuffer}` with host-side `getindex`/`setindex!`), the result can live in host USM instead: oneMKL writes straight into host-visible memory and we read it with a plain load. The C wrappers `wait_and_throw()` before returning, so the value is ready as soon as the `ccall` is.

New helper in `lib/mkl/utils.jl`:

```julia
function scalar_result(::Type{T}) where {T}
    res = oneArray{T, 1, oneL0.HostBuffer}(undef, 1)
    res[1] = zero(T)
    return res
end
```

Applied to all five sites in `lib/mkl/wrappers_blas.jl`: `nrm2`, `dot`/`dotc`/`dotu`, `asum`, `iamax`, `iamin`.

This also makes #234 moot as originally written — a dedicated `ZeHostRef` type isn't needed, since host-USM `oneArray`s cover the use case and `oneL0.host_alloc` handles the raw-pointer case.

### Performance

`nrm2` over a 4096-element `Float32` vector, Arc A750:

| | µs/call |
|---|---|
| device buffer + D2H copy | 3079.5 |
| host USM | 331.5 |

~9.5x. It's pure call overhead, so the win is independent of vector length.

### Testing

Arc A750, NEO 26.18.38308, oneMKL 2025.3.0, Julia 1.12.6:

- `test/runtests.jl onemkl` — 1112 pass, 48 broken, SUCCESS
- `test/runtests.jl gpuarrays/linalg array` — 2492 pass, SUCCESS
- All five wrappers spot-checked against `LinearAlgebra` for `Float32`/`Float64`/`ComplexF32`/`ComplexF64`

### Notes

Two pre-existing things I left alone, happy to fold in if you'd rather:

- `iamin` is typed `x::StridedArray{$elty}` where every sibling uses `oneStridedArray` (`wrappers_blas.jl:838`).
- These wrappers ignore the `int` status the C functions return, so a oneMKL exception surfaces as a silent zero rather than an error. That's why `scalar_result` zero-initializes rather than leaving the buffer `undef` — it preserves the current behaviour on that path instead of returning garbage.
