### PR TITLE
Only convert alpha/beta when the element type is an MKL type.

### DIFF
--- a/lib/mkl/linalg.jl
+++ b/lib/mkl/linalg.jl
@@ -159,7 +159,8 @@ function LinearAlgebra.generic_matmatmul!(
 
     T = eltype(C)
 
-    if alpha isa Union{Bool,T} && beta isa Union{Bool,T}
+    if T <: Union{onemklFloat, onemklComplex, onemklHalf} &&
+            alpha isa Union{Bool,T} && beta isa Union{Bool,T}
         # TODO: should the gemm part above be included in this branch?
         α, β = T(alpha), T(beta)
         if (


### PR DESCRIPTION
`*` calls `generic_matmatmul!` with `alpha::Bool`, so the `Bool` arm of `alpha isa Union{Bool,T}` admits any element type, and `T(alpha)` then errors for types that aren't constructible from a `Bool` (`MethodError: no method matching SVector{2,Float32}(::Bool)`) before we ever reach the `GPUArrays.generic_matmatmul!` fallback at the bottom.

Only the BLAS branches consume the converted values, and both already require an MKL element type, so hoisting that requirement into the guard doesn't change which operations take the MKL path.

Exposed by the new `linalg/mul!/mixed-eltype` testsuite entry from JuliaGPU/GPUArrays.jl#758.