### PR TITLE
Retry test failures

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -26,4 +26,4 @@ oneAPI = "8f75cd03-7ff8-4ecb-9b8f-daf728133b1b"
 oneAPI_Support_jll = "b049733a-a71d-5ed3-8eba-7d323ac00b36"
 
 [compat]
-ParallelTestRunner = "2.2"
+ParallelTestRunner = "2.8"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -182,4 +182,5 @@ end
 
 # Retry test failures once to give a chance to memory-pressure related failures to pass
 runtests(oneAPI, args; testsuite, init_code, init_worker_code, env = worker_env,
-                       recycle_on_failure = true, retries = 1)
+    recycle_on_failure = true, retries = 1
+)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -180,17 +180,6 @@ init_code = quote
            ..@grab_output, ..@on_device, ..sink
 end
 
-# On memory-pressured GPUs (e.g. 8GB cards) a failing test can leave the worker — or even
-# the driver — in a state where every subsequent allocation fails, so recycle workers on
-# failure and give failed files one exclusive retry on an otherwise-idle device.
-# These options are not available in every ParallelTestRunner release, so detect them
-# rather than gating on a version number.
-runtests_kwargs = Set(Iterators.flatten(Base.kwarg_decl.(methods(ParallelTestRunner.runtests))))
-failure_handling = if :recycle_on_failure in runtests_kwargs
-    (; recycle_on_failure = true, retries = 1)
-else
-    (;)
-end
-
+# Retry test failures once to give a chance to memory-pressure related failures to pass
 runtests(oneAPI, args; testsuite, init_code, init_worker_code, env = worker_env,
-         failure_handling...)
+                       recycle_on_failure = true, retries = 1)


### PR DESCRIPTION
Revert the hacky workaround.

Runic fails because this branch is in a fork but it was run