### PR TITLE
Fix fork-PR push to ALCF GitLab

### DIFF
--- a/.github/workflows/alcf.yml
+++ b/.github/workflows/alcf.yml
@@ -53,7 +53,7 @@ jobs:
           PR: ${{ github.event.pull_request.number }}
         run: |
           git init -q head && cd head
-          git fetch -q --depth=1 "https://github.com/$GITHUB_REPOSITORY" "pull/$PR/head"
+          git fetch -q "https://github.com/$GITHUB_REPOSITORY" "pull/$PR/head"
           if [ "$(git rev-parse FETCH_HEAD)" != "$HEAD_SHA" ]; then
             echo "::error::PR head moved since labeling; re-apply the label"
             exit 1


### PR DESCRIPTION
The label-gated fork-PR step fetched the PR head with `--depth=1`, and the GitLab server rejects pushes from shallow repositories (`shallow update not allowed`, seen on #617). Fetch the full history instead.