### PR TITLE
Apply β in generic_matmatmul!/generic_matvecmul! when the inner dimension is empty.

### DIFF
--- a/lib/mkl/linalg.jl
+++ b/lib/mkl/linalg.jl
@@ -83,15 +83,13 @@ function LinearAlgebra.generic_matvecmul!(Y::oneVector, tA::AbstractChar, A::one
         throw(DimensionMismatch("first dimension of A, $mA, does not match length of Y, $(length(Y))"))
     end
 
-    if mA == 0
-        return Y
-    end
-
-    if nA == 0
-        return rmul!(Y, 0)
-    end
-
     T = eltype(Y)
+
+    # an empty inner dimension still needs to apply beta: Y := b*Y
+    if mA == 0 || nA == 0
+        return iszero(b) ? fill!(Y, zero(T)) : rmul!(Y, b)
+    end
+
     alpha, beta = promote(a, b, zero(T))
     if alpha isa Union{Bool,T} && beta isa Union{Bool,T}
         if T <: onemklFloat && eltype(A) == eltype(B) == T
@@ -148,16 +146,15 @@ function LinearAlgebra.generic_matmatmul!(
         )
     )
 
+    # an empty inner dimension still needs to apply beta: C := beta*C
     if mA == 0 || nA == 0 || nB == 0
         size(C) != (mA, nB) && throw(
             DimensionMismatch(
                 "C has dimensions $(size(C)), should have ($mA,$nB)"
             )
         )
-        return LinearAlgebra.rmul!(C, 0)
+        return iszero(beta) ? fill!(C, zero(T)) : rmul!(C, beta)
     end
-
-    T = eltype(C)
 
     if T <: Union{onemklFloat, onemklComplex, onemklHalf} &&
             alpha isa Union{Bool,T} && beta isa Union{Bool,T}

--- a/src/oneAPIKernels.jl
+++ b/src/oneAPIKernels.jl
@@ -90,7 +90,8 @@ function KA.launch_config(kernel::KA.Kernel{oneAPIBackend}, ndrange, workgroupsi
     iterspace, dynamic = if KA.workgroupsize(kernel) <: KA.DynamicSize &&
         workgroupsize === nothing
         # use ndrange as preliminary workgroupsize for autotuning
-        KA.partition(kernel, ndrange, ndrange)
+        # (clamped to 1, since an empty ndrange cannot serve as a workgroup size)
+        KA.partition(kernel, ndrange, max.(ndrange, 1))
     else
         KA.partition(kernel, ndrange, workgroupsize)
     end
@@ -101,7 +102,7 @@ end
 function threads_to_workgroupsize(threads, ndrange)
     total = 1
     return map(ndrange) do n
-        x = min(div(threads, total), n)
+        x = max(1, min(div(threads, total), n))
         total *= x
         return x
     end


### PR DESCRIPTION
The empty-operand shortcuts unconditionally zeroed the output, but for K == 0 the result is β*C (as LinearAlgebra's _rmul_or_fill! does).

Also clamp the preliminary workgroup size in launch_config to at least 1, so launching a kernel over an empty ndrange (e.g. rmul! on a 0×N array) takes the groups == 0 early return instead of throwing a DivideError.

Uncovered by the K == 0 tests added in JuliaGPU/GPUArrays.jl#773.