### PR TITLE
Adapt to the library-based SPIRV_LLVM_Translator_jll 23 and GPUCompiler 2.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -32,6 +32,9 @@ oneAPI_Level_Zero_Headers_jll = "f4bc562b-d309-54f8-9efb-476e56f0410d"
 oneAPI_Level_Zero_Loader_jll = "13eca655-d68d-5b81-8367-6d99d727ab01"
 oneAPI_Support_jll = "b049733a-a71d-5ed3-8eba-7d323ac00b36"
 
+[sources]
+GPUCompiler = {url = "https://github.com/JuliaGPU/GPUCompiler.jl", rev = "tb/llvm23-jlls"}
+
 [compat]
 AbstractFFTs = "1.5.0"
 AcceleratedKernels = "0.3.1, 0.4"
@@ -39,7 +42,7 @@ Adapt = "4"
 CEnum = "0.4, 0.5"
 ExprTools = "0.1"
 GPUArrays = "11.5.14"
-GPUCompiler = "2.7"
+GPUCompiler = "2.8"
 GPUToolbox = "0.1, 0.2, 0.3, 1, 3"
 KernelAbstractions = "0.9.39"
 LLVM = "6, 7, 8, 9"
@@ -48,7 +51,7 @@ PrecompileTools = "1"
 Preferences = "1"
 SPIRVIntrinsics = "1"
 SPIRV_LLVM_Backend_jll = "23"
-SPIRV_LLVM_Translator_jll = "21"
+SPIRV_LLVM_Translator_jll = "23"
 SPIRV_Tools_jll = "2025.4.0"
 SpecialFunctions = "1.3, 2"
 StaticArrays = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -32,9 +32,6 @@ oneAPI_Level_Zero_Headers_jll = "f4bc562b-d309-54f8-9efb-476e56f0410d"
 oneAPI_Level_Zero_Loader_jll = "13eca655-d68d-5b81-8367-6d99d727ab01"
 oneAPI_Support_jll = "b049733a-a71d-5ed3-8eba-7d323ac00b36"
 
-[sources]
-GPUCompiler = {url = "https://github.com/JuliaGPU/GPUCompiler.jl", rev = "tb/llvm23-jlls"}
-
 [compat]
 AbstractFFTs = "1.5.0"
 AcceleratedKernels = "0.3.1, 0.4"


### PR DESCRIPTION
Bumps the compat bounds to SPIRV_LLVM_Translator_jll 23 (JuliaPackaging/Yggdrasil#14757, which ships `libllvm_spirv` instead of the `llvm-spirv` executable) and GPUCompiler 2.8 (JuliaGPU/GPUCompiler.jl#931), which translates through that library in-process. oneAPI itself only uses the translator through GPUCompiler, so this is compat-only.